### PR TITLE
Add exact arithmetic with fractions.Fraction

### DIFF
--- a/docs/api/panchi.md
+++ b/docs/api/panchi.md
@@ -36,6 +36,12 @@ import panchi as pan
 
 ::: panchi.rotation_matrix_3d
 
+## Exact arithmetic factories
+
+::: panchi.exact_vector
+
+::: panchi.exact_matrix
+
 ## Vector operations
 
 ::: panchi.dot

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -48,6 +48,19 @@ D = pan.diagonal([1, 2, 3])
 R = pan.rotation_matrix_2d(3.14159 / 2)
 ```
 
+## Exact Arithmetic
+
+panchi supports exact fractions — write them as strings and they stay exact through every operation:
+
+```python
+v = pan.Vector(["1/3", "2/3", "1/2"])
+A = pan.exact_matrix([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
+inv = pan.inverse(A).inverse
+print(A @ inv)  # exact identity matrix, no floating-point drift
+```
+
+See the [Exact Arithmetic guide](user-guide/exact-arithmetic.md) for the full story.
+
 ## Algorithms
 
 Algorithms return result objects that carry both the answer and the work behind it.

--- a/docs/user-guide/exact-arithmetic.md
+++ b/docs/user-guide/exact-arithmetic.md
@@ -1,0 +1,159 @@
+# Exact Arithmetic
+
+When working with linear algebra by hand, fractions like $\frac{1}{3}$ stay exact. But computers default to floating-point, which introduces rounding errors — $0.333...$ instead of $\frac{1}{3}$, or $0.9999...$ instead of $1$.
+
+panchi supports exact rational arithmetic using Python's `fractions.Fraction`. This means $\frac{1}{3}$ stays $\frac{1}{3}$ through every operation — RREF, solve, inverse, determinant — with zero rounding.
+
+## Writing fractions
+
+The simplest way to use fractions is to write them as strings:
+
+```python
+import panchi as pan
+
+v = pan.Vector(["1/3", "2/3", "1/2"])
+print(v)  # [1/3, 2/3, 1/2]
+```
+
+You can mix fractions with regular numbers:
+
+```python
+v = pan.Vector(["1/3", 2, 0])
+print(v)  # [1/3, 2, 0]
+```
+
+Matrices work the same way:
+
+```python
+A = pan.Matrix([["1/2", "1/3"],
+                ["1/4", "1/5"]])
+print(A)
+# [[1/2, 1/3],
+#  [1/4, 1/5]]
+```
+
+Negative fractions use a minus sign in the numerator:
+
+```python
+v = pan.Vector(["-1/3", "5/7"])
+```
+
+## Factory functions
+
+If you want all elements to be exact (even integers), use the factory functions:
+
+```python
+v = pan.exact_vector([1, 2, 3])
+A = pan.exact_matrix([[1, 2, 3],
+                      [4, 5, 6],
+                      [7, 8, 10]])
+```
+
+These convert every element to `Fraction`, ensuring that all subsequent arithmetic stays exact. This is especially useful when division would normally produce floats:
+
+```python
+v = pan.exact_vector([1, 2, 3])
+print(v / 3)  # [1/3, 2/3, 1]   — not [0.333..., 0.666..., 1.0]
+```
+
+## Using Fraction directly
+
+You can also use Python's `Fraction` type directly:
+
+```python
+from fractions import Fraction
+
+v = pan.Vector([Fraction(1, 3), Fraction(2, 3)])
+```
+
+panchi re-exports `Fraction` for convenience:
+
+```python
+from panchi import Fraction
+```
+
+## Exact algorithms
+
+All panchi algorithms work with fractions out of the box. The results are exact — no floating-point drift.
+
+### RREF
+
+```python
+from panchi.algorithms import rref
+
+A = pan.exact_matrix([[1, 2, 3],
+                      [4, 5, 6],
+                      [7, 8, 10]])
+
+reduction = rref(A)
+print(reduction.result)
+# [[1, 0, 0],
+#  [0, 1, 0],
+#  [0, 0, 1]]
+```
+
+### Inverse
+
+```python
+A = pan.exact_matrix([[1, 2, 3],
+                      [4, 5, 6],
+                      [7, 8, 10]])
+
+result = pan.inverse(A)
+print(result.inverse)
+# [[-2/3, -4/3, 1],
+#  [-2/3, 11/3, -2],
+#  [1, -2, 1]]
+
+# Verify: A @ A⁻¹ = I (exactly, not approximately)
+print(A @ result.inverse)
+# [[1, 0, 0],
+#  [0, 1, 0],
+#  [0, 0, 1]]
+```
+
+### Solve
+
+```python
+A = pan.exact_matrix([[2, 1],
+                      [5, 3]])
+b = pan.exact_vector([1, 2])
+
+result = pan.solve(A, b)
+print(result.solution)  # [1, -1]
+```
+
+### Determinant
+
+```python
+A = pan.exact_matrix([[1, 2], [3, 4]])
+print(A.determinant)  # -2
+```
+
+## When to use exact arithmetic
+
+**Use exact arithmetic when:**
+
+- You're learning linear algebra and want to see clean results
+- You need to verify that $A A^{-1} = I$ exactly
+- You're working through textbook problems with rational answers
+- Floating-point drift is obscuring the mathematical structure
+
+**Stick with floats when:**
+
+- You need `normalize()` or `magnitude` (these involve square roots, which are irrational)
+- You're working with measured/experimental data
+- Performance matters for large matrices
+
+## Backward compatibility
+
+Existing code is unaffected. `Vector([1, 2, 3])` with integers stays as integers. Fractions are opt-in — you choose to use them by passing string fractions or using `exact_vector()` / `exact_matrix()`.
+
+```python
+# These still work exactly as before
+v = pan.Vector([1, 2, 3])
+print(type(v[0]))  # <class 'int'>
+
+w = pan.Vector([1.0, 2.0, 3.0])
+print(type(w[0]))  # <class 'float'>
+```

--- a/docs/user-guide/matrices.md
+++ b/docs/user-guide/matrices.md
@@ -17,6 +17,15 @@ print(A.cols)   # 3
 
 Every row must have the same number of columns. Inconsistent rows raise a `ValueError`.
 
+Matrices accept fractions as strings:
+
+```python
+A = pan.Matrix([["1/2", "1/3"],
+                ["1/4", "1/5"]])
+```
+
+See [Exact Arithmetic](exact-arithmetic.md) for more on working with rational numbers.
+
 ## Arithmetic
 
 ```python

--- a/docs/user-guide/vectors.md
+++ b/docs/user-guide/vectors.md
@@ -12,7 +12,14 @@ print(v)       # [1, 2, 3]
 print(v.dims)  # 3
 ```
 
-Vectors can only hold numbers (int or float). Passing anything else raises a `TypeError` with an explanation.
+Vectors hold numbers (int, float, or Fraction). You can write fractions as strings:
+
+```python
+v = pan.Vector(["1/3", "2/3", "1/2"])
+print(v)  # [1/3, 2/3, 1/2]
+```
+
+For full details on exact arithmetic, see [Exact Arithmetic](exact-arithmetic.md).
 
 ## Arithmetic
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -56,6 +56,7 @@ nav:
   - User Guide:
     - Vectors: user-guide/vectors.md
     - Matrices: user-guide/matrices.md
+    - Exact Arithmetic: user-guide/exact-arithmetic.md
     - Vector Spaces: user-guide/vector-spaces.md
     - Linear Transformations: user-guide/transformations.md
     - Row Operations: user-guide/row-operations.md

--- a/panchi/__init__.py
+++ b/panchi/__init__.py
@@ -7,6 +7,9 @@ for students, educators, and anyone who wants to see how linear algebra really w
 
 __version__ = "0.3.0b1"
 
+from fractions import Fraction
+
+from panchi.types import Scalar
 from panchi.primitives.vector import Vector
 from panchi.primitives.matrix import Matrix
 from panchi.primitives.vector_space import VectorSpace
@@ -22,12 +25,16 @@ from panchi.primitives.factories import (
     random_matrix,
     rotation_matrix_2d,
     rotation_matrix_3d,
+    vector_column_matrix,
+    exact_vector,
+    exact_matrix,
 )
-from panchi.primitives.factories import vector_column_matrix
 from panchi.algorithms.vector_operations import dot, cross, orthogonal_complement
 from panchi.algorithms.matrix_operations import inverse, solve, determinant_lu
 
 __all__ = [
+    "Fraction",
+    "Scalar",
     "Vector",
     "Matrix",
     "VectorSpace",
@@ -43,6 +50,8 @@ __all__ = [
     "rotation_matrix_2d",
     "rotation_matrix_3d",
     "vector_column_matrix",
+    "exact_vector",
+    "exact_matrix",
     "dot",
     "cross",
     "orthogonal_complement",

--- a/panchi/algorithms/matrix_operations.py
+++ b/panchi/algorithms/matrix_operations.py
@@ -1,3 +1,4 @@
+from panchi.types import Scalar
 from panchi.primitives.matrix import Matrix
 from panchi.primitives.vector import Vector
 from panchi.primitives.factories import identity
@@ -34,7 +35,7 @@ def _calculate_inverse(n: int, steps: list[RowOperation]) -> Matrix:
     return result
 
 
-def _main_diagonal_product(matrix: Matrix) -> float:
+def _main_diagonal_product(matrix: Matrix) -> Scalar:
     """
     Compute the product of all entries on the main diagonal.
 

--- a/panchi/algorithms/row_operations.py
+++ b/panchi/algorithms/row_operations.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 from typing import overload
 
+from panchi.types import Scalar, SCALAR_TYPES
 from panchi.primitives.matrix import Matrix
 from panchi.primitives.vector import Vector
 from panchi.primitives.factories import identity
@@ -323,8 +324,8 @@ class RowSwap(RowOperation):
         self._validate_indices(n)
 
         grid: Matrix = identity(n)
-        row_a: list[int | float] = grid[self.a].copy()
-        row_b: list[int | float] = grid[self.b].copy()
+        row_a: list[Scalar] = grid[self.a].copy()
+        row_b: list[Scalar] = grid[self.b].copy()
         grid[self.a] = row_b
         grid[self.b] = row_a
 
@@ -415,7 +416,7 @@ class RowScale(RowOperation):
     ----------
     row : int
         Index of the row to scale (0-based).
-    scalar : int | float
+    scalar : int | float | Fraction
         The non-zero value to multiply the row by.
 
     Examples
@@ -437,7 +438,7 @@ class RowScale(RowOperation):
     'RowScale(row=1, scalar=3)'
     """
 
-    def __init__(self, row: int, scalar: int | float) -> None:
+    def __init__(self, row: int, scalar: Scalar) -> None:
         self.row = row
         self.scalar = scalar
         self._validate_row_type()
@@ -484,13 +485,13 @@ class RowScale(RowOperation):
         Raises
         ------
         TypeError
-            If scalar is not an int or float.
+            If scalar is not an int, float, or Fraction.
         ValueError
             If scalar is zero.
         """
-        if not isinstance(self.scalar, (int, float)):
+        if not isinstance(self.scalar, SCALAR_TYPES):
             raise TypeError(
-                f"Scalar must be a number (int or float). "
+                f"Scalar must be a number (int, float, or Fraction). "
                 f"Got {type(self.scalar).__name__}."
             )
 
@@ -633,7 +634,7 @@ class RowAdd(RowOperation):
         Index of the row being modified (0-based).
     source : int
         Index of the row being added (0-based). Must differ from target.
-    scalar : int | float
+    scalar : int | float | Fraction
         The value to multiply the source row by before adding.
 
     Examples
@@ -655,7 +656,7 @@ class RowAdd(RowOperation):
     'RowAdd(target=1, source=0, scalar=-3)'
     """
 
-    def __init__(self, target: int, source: int, scalar: int | float) -> None:
+    def __init__(self, target: int, source: int, scalar: Scalar) -> None:
         self.target = target
         self.source = source
         self.scalar = scalar
@@ -720,11 +721,11 @@ class RowAdd(RowOperation):
         Raises
         ------
         TypeError
-            If scalar is not an int or float.
+            If scalar is not an int, float, or Fraction.
         """
-        if not isinstance(self.scalar, (int, float)):
+        if not isinstance(self.scalar, SCALAR_TYPES):
             raise TypeError(
-                f"Scalar must be a number (int or float). "
+                f"Scalar must be a number (int, float, or Fraction). "
                 f"Got {type(self.scalar).__name__}."
             )
 

--- a/panchi/algorithms/vector_operations.py
+++ b/panchi/algorithms/vector_operations.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+from panchi.types import Scalar
 from panchi.primitives.vector import Vector
 
 
-def dot(vector_1: Vector, vector_2: Vector) -> float:
+def dot(vector_1: Vector, vector_2: Vector) -> Scalar:
     """
     Compute the dot product (inner product) of two vectors.
 
@@ -19,7 +20,7 @@ def dot(vector_1: Vector, vector_2: Vector) -> float:
 
     Returns
     -------
-    float
+    int | float | Fraction
         The dot product of the two vectors.
 
     Raises

--- a/panchi/primitives/__init__.py
+++ b/panchi/primitives/__init__.py
@@ -18,6 +18,8 @@ from panchi.primitives.factories import (
     rotation_matrix_2d,
     rotation_matrix_3d,
     vector_column_matrix,
+    exact_vector,
+    exact_matrix,
 )
 
 __all__ = [
@@ -36,4 +38,6 @@ __all__ = [
     "rotation_matrix_2d",
     "rotation_matrix_3d",
     "vector_column_matrix",
+    "exact_vector",
+    "exact_matrix",
 ]

--- a/panchi/primitives/factories.py
+++ b/panchi/primitives/factories.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 import random
+from fractions import Fraction
 from math import pi, cos, sin
 
 from panchi.primitives.vector import Vector
@@ -248,7 +249,7 @@ def unit_vector(dims: int, index: int) -> Vector:
     return Vector([1 if i == index else 0 for i in range(dims)])
 
 
-def diagonal(values: list[int | float] | Vector) -> Matrix:
+def diagonal(values: list | Vector) -> Matrix:
     """
     Create a diagonal matrix from a list of values.
 
@@ -257,7 +258,7 @@ def diagonal(values: list[int | float] | Vector) -> Matrix:
 
     Parameters
     ----------
-    values : list[int | float] | Vector
+    values : list[int | float | Fraction] | Vector
         The diagonal values.
 
     Returns
@@ -466,6 +467,69 @@ def rotation_matrix_3d(
     ]
 
     return Matrix([row_1, row_2, row_3])
+
+def exact_vector(data: list) -> Vector:
+    """
+    Create a Vector with all elements converted to Fraction for exact arithmetic.
+
+    This is a convenience factory for working with exact rational arithmetic.
+    All numeric inputs (int, float, string fractions) are converted to Fraction
+    values, ensuring that all subsequent arithmetic stays exact.
+
+    Parameters
+    ----------
+    data : list
+        A list of values to convert. Accepts int, float, Fraction, or strings
+        like '1/3'.
+
+    Returns
+    -------
+    Vector
+        A Vector with all Fraction components.
+
+    Examples
+    --------
+    >>> v = exact_vector([1, 2, 3])
+    >>> print(v)
+    [1, 2, 3]
+    >>> v2 = exact_vector([1, 2, 3])
+    >>> result = v2 / 3
+    >>> print(result)
+    [1/3, 2/3, 1]
+    """
+    return Vector([Fraction(x) if not isinstance(x, Fraction) else x for x in data])
+
+
+def exact_matrix(data: list[list]) -> Matrix:
+    """
+    Create a Matrix with all elements converted to Fraction for exact arithmetic.
+
+    This is a convenience factory for working with exact rational arithmetic.
+    All numeric inputs (int, float, string fractions) are converted to Fraction
+    values, ensuring that all subsequent arithmetic stays exact.
+
+    Parameters
+    ----------
+    data : list[list]
+        A 2D list of values to convert. Accepts int, float, Fraction, or strings
+        like '1/3'.
+
+    Returns
+    -------
+    Matrix
+        A Matrix with all Fraction components.
+
+    Examples
+    --------
+    >>> m = exact_matrix([[1, 2], [3, 4]])
+    >>> print(m)
+    [[1, 2],
+     [3, 4]]
+    """
+    return Matrix(
+        [[Fraction(x) if not isinstance(x, Fraction) else x for x in row] for row in data]
+    )
+
 
 def vector_column_matrix(vectors: list[Vector]) -> Matrix:
     # Add type guard

--- a/panchi/primitives/matrix.py
+++ b/panchi/primitives/matrix.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
+from fractions import Fraction
 from typing import Iterator, overload
 
+from panchi.types import Scalar, SCALAR_TYPES, parse_scalar
 from panchi.primitives.vector import Vector
 
 
@@ -14,12 +16,13 @@ class Matrix:
 
     Parameters
     ----------
-    data : list[list[int | float]]
+    data : list[list[int | float | Fraction | str]]
         A 2D list representing the matrix. All rows must have the same length.
+        Strings like '1/3' are automatically parsed as Fraction values.
 
     Attributes
     ----------
-    data : list[list[int | float]]
+    data : list[list[int | float | Fraction]]
         The underlying 2D list of matrix elements.
     shape : tuple[int, int]
         The dimensions of the matrix as (rows, columns).
@@ -41,7 +44,7 @@ class Matrix:
      [3, 4]]
     """
 
-    def __init__(self, data: list[list[int | float]]) -> None:
+    def __init__(self, data: list[list[int | float | Fraction | str]]) -> None:
         if not isinstance(data, list):
             raise TypeError(
                 f"Matrix data must be a list. Got {type(data).__name__} instead."
@@ -55,17 +58,23 @@ class Matrix:
                 f"All rows must be lists. Found invalid row type(s): {', '.join(set(bad_types))}"
             )
 
+        parsed_data = []
         if data:
             for i, row in enumerate(data):
+                parsed_row = []
                 for j, elem in enumerate(row):
-                    if not isinstance(elem, (int, float)):
+                    try:
+                        parsed_row.append(parse_scalar(elem))
+                    except TypeError:
                         raise TypeError(
-                            f"All matrix elements must be numbers (int or float). "
+                            f"All matrix elements must be numbers (int, float, Fraction, "
+                            f"or string like '1/3'). "
                             f"Found {type(elem).__name__} at position [{i}][{j}]."
                         )
+                parsed_data.append(parsed_row)
 
-        self.data = data
-        self.shape = (len(self.data), len(self.data[0])) if data else (0, 0)
+        self.data = parsed_data
+        self.shape = (len(self.data), len(self.data[0])) if parsed_data else (0, 0)
 
         if self.data:
             expected_cols = self.cols
@@ -147,7 +156,7 @@ class Matrix:
 
         return Matrix(result)
 
-    def __getitem__(self, index: int) -> list[int | float]:
+    def __getitem__(self, index: int) -> list[Scalar]:
         """
         Access a row of the matrix by index.
 
@@ -158,7 +167,7 @@ class Matrix:
 
         Returns
         -------
-        list[int | float]
+        list[int | float | Fraction]
             The row at the specified index.
 
         Raises
@@ -185,7 +194,7 @@ class Matrix:
 
         return self.data[index]
 
-    def __setitem__(self, index: int, new_row: list[int | float]) -> None:
+    def __setitem__(self, index: int, new_row: list[Scalar]) -> None:
         """
         Replace a row of the matrix at a given index.
 
@@ -197,7 +206,7 @@ class Matrix:
         ----------
         index : int
             The row index (0-based). Negative indices are supported.
-        new_row : list[int | float]
+        new_row : list[int | float | Fraction]
             The new row to assign. Must contain only numbers and have the
             same length as the other rows in this matrix.
 
@@ -226,9 +235,9 @@ class Matrix:
             raise TypeError(f"Row must be a list. Got {type(new_row).__name__}.")
 
         for j, elem in enumerate(new_row):
-            if not isinstance(elem, (int, float)):
+            if not isinstance(elem, SCALAR_TYPES):
                 raise TypeError(
-                    f"All row elements must be numbers (int or float). "
+                    f"All row elements must be numbers (int, float, or Fraction). "
                     f"Found {type(elem).__name__} at position [{j}]."
                 )
 
@@ -460,7 +469,7 @@ class Matrix:
 
         return self._apply_transformation(other)
 
-    def __rmul__(self, other: int | float) -> Matrix:
+    def __rmul__(self, other: Scalar) -> Matrix:
         """
         Multiply matrix by a scalar (from the left).
 
@@ -468,7 +477,7 @@ class Matrix:
 
         Parameters
         ----------
-        other : int | float
+        other : int | float | Fraction
             The scalar to multiply by.
 
         Returns
@@ -489,10 +498,10 @@ class Matrix:
         [[3, 6],
          [9, 12]]
         """
-        if not isinstance(other, (int, float)):
+        if not isinstance(other, SCALAR_TYPES):
             raise TypeError(
                 f"Cannot multiply Matrix by {type(other).__name__}. "
-                f"Scalar must be a number (int or float)."
+                f"Scalar must be a number (int, float, or Fraction)."
             )
 
         result = []
@@ -644,7 +653,10 @@ class Matrix:
         [[1, 2],
          [3, 4]]
         """
-        rows = ",\n ".join(str(row) for row in self.data)
+        formatted_rows = []
+        for row in self.data:
+            formatted_rows.append("[" + ", ".join(str(x) for x in row) + "]")
+        rows = ",\n ".join(formatted_rows)
         return f"[{rows}]"
 
     def __repr__(self) -> str:
@@ -855,7 +867,7 @@ class Matrix:
         return det
 
     @property
-    def trace(self) -> int | float:
+    def trace(self) -> Scalar:
         """
         Calculate the trace of the matrix.
 
@@ -865,7 +877,7 @@ class Matrix:
 
         Returns
         -------
-        int | float
+        int | float | Fraction
             The sum of the diagonal elements.
 
         Raises
@@ -1028,13 +1040,13 @@ class Matrix:
 
         return Matrix(result)
 
-    def to_list(self) -> list[list[int | float]]:
+    def to_list(self) -> list[list[Scalar]]:
         """
         Convert the matrix to a 2D list.
 
         Returns
         -------
-        list[list[int | float]]
+        list[list[int | float | Fraction]]
             A copy of the matrix data as a 2D list.
 
         Examples

--- a/panchi/primitives/vector.py
+++ b/panchi/primitives/vector.py
@@ -1,5 +1,8 @@
 from __future__ import annotations
+from fractions import Fraction
 from typing import Iterator
+
+from panchi.types import Scalar, SCALAR_TYPES, parse_scalar
 
 
 class Vector:
@@ -12,12 +15,13 @@ class Vector:
 
     Parameters
     ----------
-    data : list[int | float]
-        A list of numbers representing the vector components.
+    data : list[int | float | Fraction | str]
+        A list of numbers representing the vector components. Strings
+        like '1/3' are automatically parsed as Fraction values.
 
     Attributes
     ----------
-    data : list[int | float]
+    data : list[int | float | Fraction]
         The underlying list of vector components.
     shape : tuple[int, int]
         The dimensions of the vector as (dims, 1).
@@ -36,16 +40,24 @@ class Vector:
     [1, 2, 3]
     """
 
-    def __init__(self, data: list[int | float]) -> None:
-        if not (
-            isinstance(data, list) and all(isinstance(x, (int, float)) for x in data)
-        ):
+    def __init__(self, data: list[int | float | Fraction | str]) -> None:
+        if not isinstance(data, list):
             raise TypeError("Vectors can only be created with lists of numbers")
 
-        self.data = data
-        self.shape = (len(data), 1)
+        parsed = []
+        for i, x in enumerate(data):
+            try:
+                parsed.append(parse_scalar(x))
+            except TypeError:
+                raise TypeError(
+                    f"All vector elements must be numbers (int, float, Fraction, "
+                    f"or string like '1/3'). Found {type(x).__name__} at index {i}."
+                )
 
-    def __getitem__(self, key: int) -> int | float:
+        self.data = parsed
+        self.shape = (len(parsed), 1)
+
+    def __getitem__(self, key: int) -> Scalar:
         """
         Access a vector component by index.
 
@@ -56,7 +68,7 @@ class Vector:
 
         Returns
         -------
-        int | float
+        int | float | Fraction
             The value at the specified index.
 
         Raises
@@ -77,7 +89,7 @@ class Vector:
 
         return self.data[key]
 
-    def __setitem__(self, key: int, new_value: int | float) -> None:
+    def __setitem__(self, key: int, new_value: Scalar) -> None:
         """
         Set a vector component at a specific index.
 
@@ -85,7 +97,7 @@ class Vector:
         ----------
         key : int
             The index (0-based) of the component to modify.
-        new_value : int | float
+        new_value : int | float | Fraction
             The new value to assign.
 
         Raises
@@ -103,7 +115,7 @@ class Vector:
         if not isinstance(key, int):
             raise TypeError("Indexes can only be integer values")
 
-        if not isinstance(new_value, (int, float)):
+        if not isinstance(new_value, SCALAR_TYPES):
             raise TypeError("Vectors can only hold numbers")
 
         self.data[key] = new_value
@@ -229,7 +241,7 @@ class Vector:
 
         return Vector(result)
 
-    def __rmul__(self, other: int | float) -> Vector:
+    def __rmul__(self, other: Scalar) -> Vector:
         """
         Multiply vector by a scalar (from the left).
 
@@ -237,7 +249,7 @@ class Vector:
 
         Parameters
         ----------
-        other : int | float
+        other : int | float | Fraction
             The scalar to multiply by.
 
         Returns
@@ -257,7 +269,7 @@ class Vector:
         >>> print(result)
         [3, 6, 9]
         """
-        if not isinstance(other, (int, float)):
+        if not isinstance(other, SCALAR_TYPES):
             return NotImplemented
 
         result = []
@@ -267,7 +279,7 @@ class Vector:
 
         return Vector(result)
 
-    def __truediv__(self, other: int | float) -> Vector:
+    def __truediv__(self, other: Scalar) -> Vector:
         """
         Divide vector by a scalar.
 
@@ -275,7 +287,7 @@ class Vector:
 
         Parameters
         ----------
-        other : int | float
+        other : int | float | Fraction
             The scalar to divide by.
 
         Returns
@@ -295,7 +307,7 @@ class Vector:
         >>> print(result)
         [2.0, 3.0, 4.0]
         """
-        if not isinstance(other, (int, float)):
+        if not isinstance(other, SCALAR_TYPES):
             return NotImplemented
 
         result = []
@@ -374,7 +386,7 @@ class Vector:
         >>> print(v)
         [1, 2, 3]
         """
-        return f"{self.data}"
+        return "[" + ", ".join(str(x) for x in self.data) + "]"
 
     def __repr__(self) -> str:
         """
@@ -483,13 +495,13 @@ class Vector:
         """
         return Vector(self.data.copy())
 
-    def to_list(self) -> list[int | float]:
+    def to_list(self) -> list[Scalar]:
         """
         Convert the vector to a list.
 
         Returns
         -------
-        list[int | float]
+        list[int | float | Fraction]
             A copy of the vector components as a list.
 
         Examples
@@ -500,13 +512,13 @@ class Vector:
         """
         return self.data.copy()
 
-    def to_tuple(self) -> tuple[int | float, ...]:
+    def to_tuple(self) -> tuple[Scalar, ...]:
         """
         Convert the vector to a tuple.
 
         Returns
         -------
-        tuple[int | float, ...]
+        tuple[int | float | Fraction, ...]
             The vector components as a tuple.
 
         Examples

--- a/panchi/types.py
+++ b/panchi/types.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fractions import Fraction
+
+Scalar = int | float | Fraction
+SCALAR_TYPES = (int, float, Fraction)
+
+
+def parse_scalar(value) -> int | float | Fraction:
+    """Parse a value into a scalar. Strings like '1/3' become Fraction."""
+    if isinstance(value, SCALAR_TYPES):
+        return value
+    if isinstance(value, str):
+        try:
+            if "/" in value:
+                return Fraction(value)
+            try:
+                return int(value)
+            except ValueError:
+                return float(value)
+        except (ValueError, ZeroDivisionError):
+            raise TypeError(
+                f"Cannot convert string '{value}' to a number. "
+                f"Expected a numeric string or a fraction like '1/3'."
+            )
+    raise TypeError(
+        f"Cannot convert {type(value).__name__} to a number. "
+        f"Expected int, float, Fraction, or a string like '1/3'."
+    )

--- a/tests/test_fraction.py
+++ b/tests/test_fraction.py
@@ -1,0 +1,246 @@
+from fractions import Fraction
+
+import panchi as pan
+from panchi import (
+    Vector,
+    Matrix,
+    exact_vector,
+    exact_matrix,
+    dot,
+    cross,
+    identity,
+    solve,
+    inverse,
+    determinant_lu,
+)
+from panchi.algorithms.reductions import rref
+
+
+class TestVectorFractionConstruction:
+    def test_string_fractions(self):
+        v = Vector(["1/3", "2/3", "1/2"])
+        assert v[0] == Fraction(1, 3)
+        assert v[1] == Fraction(2, 3)
+        assert v[2] == Fraction(1, 2)
+
+    def test_mixed_types(self):
+        v = Vector(["1/3", 2, 3.0])
+        assert v[0] == Fraction(1, 3)
+        assert v[1] == 2
+        assert isinstance(v[1], int)
+        assert v[2] == 3.0
+        assert isinstance(v[2], float)
+
+    def test_integer_strings(self):
+        v = Vector(["1", "2", "3"])
+        assert v[0] == 1
+        assert isinstance(v[0], int)
+
+    def test_fraction_objects(self):
+        v = Vector([Fraction(1, 3), Fraction(2, 3)])
+        assert v[0] == Fraction(1, 3)
+
+    def test_invalid_string_raises(self):
+        try:
+            Vector(["hello"])
+            assert False, "Should have raised"
+        except TypeError:
+            pass
+
+    def test_negative_fractions(self):
+        v = Vector(["-1/3", "-2/5"])
+        assert v[0] == Fraction(-1, 3)
+        assert v[1] == Fraction(-2, 5)
+
+
+class TestMatrixFractionConstruction:
+    def test_string_fractions(self):
+        m = Matrix([["1/2", "1/3"], ["1/4", "1/5"]])
+        assert m[0][0] == Fraction(1, 2)
+        assert m[0][1] == Fraction(1, 3)
+        assert m[1][0] == Fraction(1, 4)
+        assert m[1][1] == Fraction(1, 5)
+
+    def test_mixed_types(self):
+        m = Matrix([["1/3", 2], [0, "3/4"]])
+        assert m[0][0] == Fraction(1, 3)
+        assert m[0][1] == 2
+        assert m[1][0] == 0
+        assert m[1][1] == Fraction(3, 4)
+
+    def test_invalid_string_raises(self):
+        try:
+            Matrix([["abc", 1], [2, 3]])
+            assert False, "Should have raised"
+        except TypeError:
+            pass
+
+
+class TestExactFactories:
+    def test_exact_vector(self):
+        v = exact_vector([1, 2, 3])
+        assert all(isinstance(v[i], Fraction) for i in range(v.dims))
+        assert v[0] == Fraction(1)
+        assert v[1] == Fraction(2)
+
+    def test_exact_matrix(self):
+        m = exact_matrix([[1, 2], [3, 4]])
+        assert isinstance(m[0][0], Fraction)
+        assert m[0][0] == Fraction(1)
+
+    def test_exact_vector_preserves_fractions(self):
+        v = exact_vector([Fraction(1, 3), 2])
+        assert v[0] == Fraction(1, 3)
+        assert v[1] == Fraction(2)
+
+
+class TestFractionArithmetic:
+    def test_vector_addition(self):
+        v1 = Vector(["1/3", "1/3", "1/3"])
+        v2 = Vector(["2/3", "2/3", "2/3"])
+        result = v1 + v2
+        assert result[0] == Fraction(1, 1)
+        assert result[1] == Fraction(1, 1)
+
+    def test_vector_subtraction(self):
+        v1 = Vector(["1/2", "3/4"])
+        v2 = Vector(["1/4", "1/4"])
+        result = v1 - v2
+        assert result[0] == Fraction(1, 4)
+        assert result[1] == Fraction(1, 2)
+
+    def test_scalar_multiplication(self):
+        v = Vector(["1/3", "2/3"])
+        result = Fraction(3) * v
+        assert result[0] == Fraction(1, 1)
+        assert result[1] == Fraction(2, 1)
+
+    def test_scalar_division(self):
+        v = exact_vector([1, 2, 3])
+        result = v / Fraction(3)
+        assert result[0] == Fraction(1, 3)
+        assert result[1] == Fraction(2, 3)
+        assert result[2] == Fraction(1, 1)
+
+    def test_matrix_addition(self):
+        m1 = Matrix([["1/2", "1/3"], ["1/4", "1/5"]])
+        m2 = Matrix([["1/2", "2/3"], ["3/4", "4/5"]])
+        result = m1 + m2
+        assert result[0][0] == Fraction(1, 1)
+        assert result[0][1] == Fraction(1, 1)
+        assert result[1][0] == Fraction(1, 1)
+        assert result[1][1] == Fraction(1, 1)
+
+    def test_matrix_scalar_multiplication(self):
+        m = Matrix([["1/3", "2/3"], ["1/6", "5/6"]])
+        result = Fraction(6) * m
+        assert result[0][0] == Fraction(2)
+        assert result[0][1] == Fraction(4)
+        assert result[1][0] == Fraction(1)
+        assert result[1][1] == Fraction(5)
+
+    def test_matrix_vector_multiplication(self):
+        m = exact_matrix([[1, 2], [3, 4]])
+        v = exact_vector([1, 1])
+        result = m @ v
+        assert result[0] == Fraction(3)
+        assert result[1] == Fraction(7)
+
+    def test_matrix_matrix_multiplication(self):
+        m1 = exact_matrix([[1, 2], [3, 4]])
+        m2 = exact_matrix([[5, 6], [7, 8]])
+        result = m1 @ m2
+        assert result[0][0] == Fraction(19)
+        assert result[0][1] == Fraction(22)
+
+
+class TestFractionDotCross:
+    def test_dot_product(self):
+        v1 = Vector(["1/2", "1/3", "1/4"])
+        v2 = Vector(["2", "3", "4"])
+        result = dot(v1, v2)
+        assert result == Fraction(1) + Fraction(1) + Fraction(1)
+        assert result == Fraction(3)
+
+    def test_cross_product(self):
+        v1 = exact_vector([1, 0, 0])
+        v2 = exact_vector([0, 1, 0])
+        result = cross(v1, v2)
+        assert result == Vector([0, 0, 1])
+
+
+class TestFractionAlgorithms:
+    def test_rref_exact(self):
+        m = exact_matrix([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
+        reduction = rref(m)
+        rref_matrix = reduction.result
+        assert rref_matrix[0][0] == Fraction(1)
+        assert rref_matrix[1][1] == Fraction(1)
+        assert rref_matrix[2][2] == Fraction(1)
+        assert rref_matrix[0][1] == Fraction(0)
+        assert rref_matrix[0][2] == Fraction(0)
+
+    def test_determinant_exact(self):
+        m = exact_matrix([[1, 2], [3, 4]])
+        det = m.determinant
+        assert det == Fraction(-2)
+
+    def test_inverse_exact(self):
+        m = exact_matrix([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
+        inv_result = inverse(m)
+        inv_matrix = inv_result.inverse
+
+        product = m @ inv_matrix
+        n = m.rows
+        for i in range(n):
+            for j in range(n):
+                if i == j:
+                    assert product[i][j] == Fraction(1)
+                else:
+                    assert product[i][j] == Fraction(0)
+
+    def test_solve_exact(self):
+        A = exact_matrix([[2, 1], [5, 3]])
+        b = exact_vector([1, 2])
+        result = solve(A, b)
+        assert result.solution[0] == Fraction(1)
+        assert result.solution[1] == Fraction(-1)
+
+    def test_determinant_lu_exact(self):
+        m = exact_matrix([[1, 2, 3], [4, 5, 6], [7, 8, 10]])
+        det = determinant_lu(m)
+        assert det == Fraction(-3)
+
+
+class TestFractionDisplay:
+    def test_vector_str(self):
+        v = Vector(["1/3", "2/3", 1])
+        assert str(v) == "[1/3, 2/3, 1]"
+
+    def test_vector_repr(self):
+        v = Vector(["1/3", "2/3"])
+        assert "Fraction" in repr(v)
+
+    def test_matrix_str(self):
+        m = Matrix([["1/2", "1/3"], ["1/4", "1/5"]])
+        s = str(m)
+        assert "1/2" in s
+        assert "1/3" in s
+
+
+class TestBackwardCompatibility:
+    def test_int_stays_int(self):
+        v = Vector([1, 2, 3])
+        result = v + Vector([4, 5, 6])
+        assert isinstance(result[0], int)
+        assert result[0] == 5
+
+    def test_float_stays_float(self):
+        v = Vector([1.0, 2.0, 3.0])
+        result = v + Vector([4.0, 5.0, 6.0])
+        assert isinstance(result[0], float)
+
+    def test_int_matrix_stays_int(self):
+        m = Matrix([[1, 2], [3, 4]])
+        result = m + Matrix([[5, 6], [7, 8]])
+        assert isinstance(result[0][0], int)


### PR DESCRIPTION
## Summary

- Add exact rational arithmetic support using stdlib `fractions.Fraction`
- Users can write fractions as strings (`"1/3"`) directly in Vector/Matrix constructors — parsed automatically
- Add `exact_vector()` and `exact_matrix()` factory functions that convert all elements to Fraction
- All existing algorithms (RREF, solve, inverse, determinant) work unchanged with Fraction inputs
- Full backward compatibility — existing int/float code behaves identically

## Test plan

- [x] All 535 existing tests still pass (backward compat verified)
- [x] 33 new tests covering: string construction, factories, arithmetic preservation, algorithm correctness, display, and backward compat
- [x] End-to-end smoke test: `A @ A⁻¹ == I` exactly with Fraction values
- [x] Docs build successfully with `mkdocs build --strict`

🤖 Generated with [Claude Code](https://claude.com/claude-code)