### PR TITLE
Release v1.2.0 — QR eigensolver, QR decomposition enrichment, tolerant solve

### DIFF
--- a/panchi/__init__.py
+++ b/panchi/__init__.py
@@ -36,7 +36,7 @@ from panchi.algorithms.vector_operations import (
     vector_projection,
     gram_schmidt,
 )
-from panchi.algorithms.matrix_operations import inverse, solve, determinant_lu
+from panchi.algorithms.matrix_operations import inverse, solve, determinant_lu, eigen
 from panchi.algorithms.decompositions import qr_decomposition
 
 __all__ = [
@@ -68,4 +68,5 @@ __all__ = [
     "solve",
     "determinant_lu",
     "qr_decomposition",
+    "eigen",
 ]

--- a/panchi/__init__.py
+++ b/panchi/__init__.py
@@ -5,7 +5,7 @@ panchi prioritizes clarity and understanding over performance, making it ideal
 for students, educators, and anyone who wants to see how linear algebra really works.
 """
 
-__version__ = "1.0.1"
+__version__ = "1.2.0"
 
 from fractions import Fraction
 

--- a/panchi/__init__.py
+++ b/panchi/__init__.py
@@ -29,8 +29,15 @@ from panchi.primitives.factories import (
     exact_vector,
     exact_matrix,
 )
-from panchi.algorithms.vector_operations import dot, cross, orthogonal_complement
+from panchi.algorithms.vector_operations import (
+    dot,
+    cross,
+    orthogonal_complement,
+    vector_projection,
+    gram_schmidt,
+)
 from panchi.algorithms.matrix_operations import inverse, solve, determinant_lu
+from panchi.algorithms.decompositions import qr_decomposition
 
 __all__ = [
     "Fraction",
@@ -55,7 +62,10 @@ __all__ = [
     "dot",
     "cross",
     "orthogonal_complement",
+    "vector_projection",
+    "gram_schmidt",
     "inverse",
     "solve",
     "determinant_lu",
+    "qr_decomposition",
 ]

--- a/panchi/algorithms/__init__.py
+++ b/panchi/algorithms/__init__.py
@@ -18,8 +18,9 @@ from panchi.algorithms.results import (
     QRDecomposition,
     InverseResult,
     Solution,
+    EigenResult,
 )
-from panchi.algorithms.matrix_operations import inverse, solve, determinant_lu
+from panchi.algorithms.matrix_operations import inverse, solve, determinant_lu, eigen
 from panchi.algorithms.vector_operations import (
     dot,
     cross,
@@ -41,9 +42,11 @@ __all__ = [
     "QRDecomposition",
     "InverseResult",
     "Solution",
+    "EigenResult",
     "inverse",
     "solve",
     "determinant_lu",
+    "eigen",
     "dot",
     "cross",
     "orthogonal_complement",

--- a/panchi/algorithms/__init__.py
+++ b/panchi/algorithms/__init__.py
@@ -12,10 +12,21 @@ find solutions to linear systems by reducing augmented matrices.
 
 from panchi.algorithms.row_operations import RowSwap, RowScale, RowAdd
 from panchi.algorithms.reductions import Reduction, ref, rref
-from panchi.algorithms.decompositions import lu
-from panchi.algorithms.results import LUDecomposition, InverseResult, Solution
+from panchi.algorithms.decompositions import lu, qr_decomposition
+from panchi.algorithms.results import (
+    LUDecomposition,
+    QRDecomposition,
+    InverseResult,
+    Solution,
+)
 from panchi.algorithms.matrix_operations import inverse, solve, determinant_lu
-from panchi.algorithms.vector_operations import dot, cross, orthogonal_complement
+from panchi.algorithms.vector_operations import (
+    dot,
+    cross,
+    orthogonal_complement,
+    vector_projection,
+    gram_schmidt,
+)
 
 __all__ = [
     "RowSwap",
@@ -25,7 +36,9 @@ __all__ = [
     "ref",
     "rref",
     "lu",
+    "qr_decomposition",
     "LUDecomposition",
+    "QRDecomposition",
     "InverseResult",
     "Solution",
     "inverse",
@@ -34,4 +47,6 @@ __all__ = [
     "dot",
     "cross",
     "orthogonal_complement",
+    "vector_projection",
+    "gram_schmidt",
 ]

--- a/panchi/algorithms/decompositions.py
+++ b/panchi/algorithms/decompositions.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
 from panchi.primitives.matrix import Matrix
-from panchi.primitives.factories import identity
+from panchi.primitives.factories import identity, vector_column_matrix
 from panchi.algorithms.reductions import ref
 from panchi.algorithms.row_operations import RowOperation, RowAdd, RowSwap
-from panchi.algorithms.results import LUDecomposition
+from panchi.algorithms.vector_operations import gram_schmidt_algorithm
+from panchi.algorithms.results import LUDecomposition, QRDecomposition
 
 
 def _calculate_l(n: int, steps: list[RowOperation]) -> Matrix:
@@ -116,3 +117,11 @@ def lu(matrix: Matrix) -> LUDecomposition:
     u = matrix_ref.result
     p = _calculate_p(n, steps)
     return LUDecomposition(matrix, l, u, p, steps)
+
+
+def qr_decomposition(matrix: Matrix) -> QRDecomposition:
+    column_vectors = matrix.col_vectors
+    orthonormal_vectors = gram_schmidt_algorithm(column_vectors)
+    q = vector_column_matrix(orthonormal_vectors)
+    r = q.T @ matrix
+    return QRDecomposition(matrix, q, r)

--- a/panchi/algorithms/decompositions.py
+++ b/panchi/algorithms/decompositions.py
@@ -4,7 +4,7 @@ from panchi.primitives.matrix import Matrix
 from panchi.primitives.factories import identity, vector_column_matrix
 from panchi.algorithms.reductions import ref
 from panchi.algorithms.row_operations import RowOperation, RowAdd, RowSwap
-from panchi.algorithms.vector_operations import gram_schmidt_algorithm
+from panchi.algorithms.vector_operations import gram_schmidt
 from panchi.algorithms.results import LUDecomposition, QRDecomposition
 
 
@@ -121,7 +121,7 @@ def lu(matrix: Matrix) -> LUDecomposition:
 
 def qr_decomposition(matrix: Matrix) -> QRDecomposition:
     column_vectors = matrix.col_vectors
-    orthonormal_vectors = gram_schmidt_algorithm(column_vectors)
+    orthonormal_vectors = gram_schmidt(column_vectors)
     q = vector_column_matrix(orthonormal_vectors)
     r = q.T @ matrix
     return QRDecomposition(matrix, q, r)

--- a/panchi/algorithms/decompositions.py
+++ b/panchi/algorithms/decompositions.py
@@ -4,7 +4,7 @@ from panchi.primitives.matrix import Matrix
 from panchi.primitives.factories import identity, vector_column_matrix
 from panchi.algorithms.reductions import ref
 from panchi.algorithms.row_operations import RowOperation, RowAdd, RowSwap
-from panchi.algorithms.vector_operations import gram_schmidt
+from panchi.algorithms.vector_operations import _gram_schmidt_steps
 from panchi.algorithms.results import LUDecomposition, QRDecomposition
 
 
@@ -120,8 +120,45 @@ def lu(matrix: Matrix) -> LUDecomposition:
 
 
 def qr_decomposition(matrix: Matrix) -> QRDecomposition:
-    column_vectors = matrix.col_vectors
-    orthonormal_vectors = gram_schmidt(column_vectors)
+    """
+    Compute the (thin) QR decomposition of a matrix.
+
+    Factors the matrix into a matrix Q with orthonormal columns and an
+    upper triangular matrix R such that matrix == Q @ R. Q is built by
+    applying Gram-Schmidt to the columns of the matrix, and R is recovered
+    as Q.T @ matrix.
+
+    This is the reduced ("thin") QR decomposition and assumes the columns
+    of the matrix are linearly independent. Dependent columns produce a zero
+    orthogonal vector during Gram-Schmidt, which cannot be normalized and
+    raises ZeroDivisionError.
+
+    Parameters
+    ----------
+    matrix : Matrix
+        The matrix to decompose. Its columns are expected to be linearly
+        independent.
+
+    Returns
+    -------
+    QRDecomposition
+        A result object containing the original matrix, Q, R, and the
+        ordered list of Gram-Schmidt steps used to build Q.
+
+    Raises
+    ------
+    ZeroDivisionError
+        If the columns of the matrix are linearly dependent.
+
+    Examples
+    --------
+    >>> A = Matrix([[1, 0], [0, 1]])
+    >>> decomp = qr_decomposition(A)
+    >>> decomp.q @ decomp.r == A
+    True
+    """
+    steps = _gram_schmidt_steps(matrix.col_vectors)
+    orthonormal_vectors = [step.orthonormal for step in steps]
     q = vector_column_matrix(orthonormal_vectors)
     r = q.T @ matrix
-    return QRDecomposition(matrix, q, r)
+    return QRDecomposition(matrix, q, r, steps)

--- a/panchi/algorithms/matrix_operations.py
+++ b/panchi/algorithms/matrix_operations.py
@@ -78,7 +78,9 @@ def _swap_parity(steps: list[RowOperation]) -> int:
     return (-1) ** swap_count
 
 
-def _inconsistent_rows(matrix_rref: Reduction, applied_b: Vector) -> list[int]:
+def _inconsistent_rows(
+    matrix_rref: Reduction, applied_b: Vector, tol: float = 0.0
+) -> list[int]:
     """
     Find row indices that make the system inconsistent.
 
@@ -93,6 +95,9 @@ def _inconsistent_rows(matrix_rref: Reduction, applied_b: Vector) -> list[int]:
     applied_b : Vector
         The right-hand side vector b after the same row operations from
         matrix_rref have been applied to it.
+    tol : float, optional
+        Entries of the transformed b with magnitude at or below this value
+        are treated as zero. The default of 0.0 means exact comparison.
 
     Returns
     -------
@@ -104,7 +109,7 @@ def _inconsistent_rows(matrix_rref: Reduction, applied_b: Vector) -> list[int]:
     zero_row_indices = set(range(matrix_rref.result.rows)) - pivot_row_indices
     inconsistent_indices = []
     for i in zero_row_indices:
-        if applied_b[i] != 0:
+        if abs(applied_b[i]) > tol:
             inconsistent_indices.append(i)
 
     return inconsistent_indices
@@ -224,7 +229,7 @@ def determinant_lu(matrix: Matrix) -> float:
     return parity * upper_diagonal_product
 
 
-def solve(A: Matrix, b: Vector) -> Solution:
+def solve(A: Matrix, b: Vector, tol: float = 0.0) -> Solution:
     """
     Solve the linear system Ax = b.
 
@@ -241,6 +246,13 @@ def solve(A: Matrix, b: Vector) -> Solution:
         The coefficient matrix in the system Ax = b.
     b : Vector
         The right-hand side vector in the system Ax = b.
+    tol : float, optional
+        Pivot and right-hand-side magnitudes at or below this value are
+        treated as zero during reduction. The default of 0.0 performs an
+        exact solve. A small positive tolerance lets the solver treat a
+        matrix that is only approximately rank-deficient as singular, which
+        is how eigenvectors are recovered as the null space of A - λI for a
+        floating-point eigenvalue estimate λ.
 
     Returns
     -------
@@ -282,14 +294,14 @@ def solve(A: Matrix, b: Vector) -> Solution:
             f"A has {A.rows} rows but b has {b.dims} entries."
         )
 
-    matrix_rref = rref(A)
+    matrix_rref = rref(A, tol)
     steps = matrix_rref.steps
 
     applied_b = b
     for step in steps:
         applied_b = step.apply(applied_b)
 
-    if _inconsistent_rows(matrix_rref, applied_b):
+    if _inconsistent_rows(matrix_rref, applied_b, tol):
         return Solution(A, b, "inconsistent", None, steps)
 
     if matrix_rref.nullity > 0:
@@ -331,6 +343,26 @@ def _below_diagonal_mass(matrix: Matrix) -> float:
     """
     n = matrix.rows
     return sum(abs(matrix[i][j]) for i in range(n) for j in range(i))
+
+
+def _eigenvector(matrix: Matrix, eigenvalue: float, n: int) -> Vector | None:
+    """
+    Find an eigenvector for a known eigenvalue as the null space of A - λI.
+
+    Solves the homogeneous system ``(A - λI) x = 0`` with a scale-relative
+    tolerance, reusing solve(). Because a floating-point λ makes ``A - λI``
+    only approximately singular, the tolerance is what lets solve() report an
+    infinite solution set and expose the null space. Returns the first
+    null-space basis vector, normalized, or None if the system is not
+    detected as rank-deficient (e.g. for tightly clustered eigenvalues).
+    """
+    shifted = matrix - eigenvalue * identity(n)
+    scale = max(1.0, max(abs(shifted[i][j]) for i in range(n) for j in range(n)))
+    solution = solve(shifted, zero_vector(n), tol=1e-6 * scale)
+
+    if solution.null_space is None:
+        return None
+    return solution.null_space.basis[0].normalize()
 
 
 def eigen(
@@ -417,4 +449,9 @@ def eigen(
 
     eigenvalues = [current[i][i] for i in range(n)]
     eigenvectors: list[Vector] = []
+    if converged:
+        for eigenvalue in eigenvalues:
+            vector = _eigenvector(matrix, eigenvalue, n)
+            if vector is not None:
+                eigenvectors.append(vector)
     return EigenResult(matrix, eigenvalues, eigenvectors, iterations, converged, current)

--- a/panchi/algorithms/matrix_operations.py
+++ b/panchi/algorithms/matrix_operations.py
@@ -1,11 +1,11 @@
 from panchi.types import Scalar
 from panchi.primitives.matrix import Matrix
 from panchi.primitives.vector import Vector
-from panchi.primitives.factories import identity
+from panchi.primitives.factories import identity, zero_vector
 from panchi.algorithms.row_operations import RowOperation, RowSwap
-from panchi.algorithms.results import InverseResult, Reduction, Solution
+from panchi.algorithms.results import InverseResult, Reduction, Solution, EigenResult
 from panchi.algorithms.reductions import rref
-from panchi.algorithms.decompositions import lu
+from panchi.algorithms.decompositions import lu, qr_decomposition
 
 
 def _calculate_inverse(n: int, steps: list[RowOperation]) -> Matrix:
@@ -319,3 +319,102 @@ def solve(A: Matrix, b: Vector) -> Solution:
     pivot_row_indices = [row for row, _ in sorted(matrix_rref.pivots, key=lambda p: p[1])]
     solution = Vector([applied_b[row] for row in pivot_row_indices])
     return Solution(A, b, "unique", solution, steps)
+
+
+def _below_diagonal_mass(matrix: Matrix) -> float:
+    """
+    Sum the absolute values of the strictly-below-diagonal entries.
+
+    Used as the convergence measure for the QR algorithm: when this sum is
+    small, the iterate is (near) upper triangular and its diagonal holds the
+    eigenvalues.
+    """
+    n = matrix.rows
+    return sum(abs(matrix[i][j]) for i in range(n) for j in range(i))
+
+
+def eigen(
+    matrix: Matrix,
+    max_iterations: int = 1000,
+    tol: float = 1e-12,
+) -> EigenResult:
+    """
+    Compute the eigenvalues of a square matrix using the QR algorithm.
+
+    Starting from the original matrix, repeatedly computes a QR
+    decomposition and reassembles the matrix as R @ Q. For matrices with
+    real eigenvalues this sequence converges to an upper triangular matrix
+    whose diagonal entries are the eigenvalues.
+
+    The iteration stops once the strictly-below-diagonal entries sum to less
+    than ``tol`` (recorded as converged), or once ``max_iterations`` is
+    reached (recorded as not converged). Eigenvalues are the diagonal of the
+    final iterate. Eigenvectors are computed separately and are only
+    populated when the iteration converges.
+
+    Only real eigenvalues are supported. Matrices with complex eigenvalues
+    or eigenvalues of equal magnitude may fail to converge, in which case the
+    returned result has ``converged`` set to False and no eigenvectors.
+
+    Parameters
+    ----------
+    matrix : Matrix
+        The square matrix whose eigenvalues will be computed.
+    max_iterations : int, optional
+        The maximum number of QR iterations to perform. Defaults to 1000.
+    tol : float, optional
+        The convergence threshold on the below-diagonal mass. Defaults to
+        1e-12.
+
+    Returns
+    -------
+    EigenResult
+        A result object containing the eigenvalues, eigenvectors, the number
+        of iterations performed, whether the iteration converged, and the
+        final (near) upper-triangular matrix.
+
+    Raises
+    ------
+    TypeError
+        If matrix is not a Matrix instance.
+    ValueError
+        If matrix is not square.
+
+    Examples
+    --------
+    >>> result = eigen(Matrix([[2, 1], [1, 2]]))
+    >>> sorted(round(v, 6) for v in result.eigenvalues)
+    [1.0, 3.0]
+    """
+    if not isinstance(matrix, Matrix):
+        raise TypeError(
+            f"Expected a Matrix, but got {type(matrix).__name__}. "
+            f"Eigenvalues are only defined for Matrix objects."
+        )
+    if not matrix.is_square:
+        raise ValueError(
+            f"Cannot compute the eigenvalues of a non-square matrix. "
+            f"Your matrix is {matrix.rows}×{matrix.cols}. "
+            f"Eigenvalues are only defined for square matrices (n×n)."
+        )
+
+    n = matrix.rows
+    current = matrix
+    converged = False
+    iterations = 0
+    for iterations in range(1, max_iterations + 1):
+        if _below_diagonal_mass(current) < tol:
+            converged = True
+            iterations -= 1
+            break
+        try:
+            decomposition = qr_decomposition(current)
+        except ZeroDivisionError:
+            # A singular iterate cannot be orthonormalized by Gram-Schmidt;
+            # treat this as failure to converge rather than crashing.
+            break
+        current = decomposition.r @ decomposition.q
+
+    eigenvalues = [current[i][i] for i in range(n)]
+    eigenvectors: list[Vector] = []
+    return EigenResult(matrix, eigenvalues, eigenvectors, iterations, converged, current)

--- a/panchi/algorithms/matrix_operations.py
+++ b/panchi/algorithms/matrix_operations.py
@@ -79,7 +79,7 @@ def _swap_parity(steps: list[RowOperation]) -> int:
 
 
 def _inconsistent_rows(
-    matrix_rref: Reduction, applied_b: Vector, tol: float = 0.0
+    matrix_rref: Reduction, applied_b: Vector, tolerance: float = 0.0
 ) -> list[int]:
     """
     Find row indices that make the system inconsistent.
@@ -95,7 +95,7 @@ def _inconsistent_rows(
     applied_b : Vector
         The right-hand side vector b after the same row operations from
         matrix_rref have been applied to it.
-    tol : float, optional
+    tolerance : float, optional
         Entries of the transformed b with magnitude at or below this value
         are treated as zero. The default of 0.0 means exact comparison.
 
@@ -109,7 +109,7 @@ def _inconsistent_rows(
     zero_row_indices = set(range(matrix_rref.result.rows)) - pivot_row_indices
     inconsistent_indices = []
     for i in zero_row_indices:
-        if abs(applied_b[i]) > tol:
+        if abs(applied_b[i]) > tolerance:
             inconsistent_indices.append(i)
 
     return inconsistent_indices
@@ -229,7 +229,7 @@ def determinant_lu(matrix: Matrix) -> float:
     return parity * upper_diagonal_product
 
 
-def solve(A: Matrix, b: Vector, tol: float = 0.0) -> Solution:
+def solve(A: Matrix, b: Vector, tolerance: float = 0.0) -> Solution:
     """
     Solve the linear system Ax = b.
 
@@ -246,7 +246,7 @@ def solve(A: Matrix, b: Vector, tol: float = 0.0) -> Solution:
         The coefficient matrix in the system Ax = b.
     b : Vector
         The right-hand side vector in the system Ax = b.
-    tol : float, optional
+    tolerance : float, optional
         Pivot and right-hand-side magnitudes at or below this value are
         treated as zero during reduction. The default of 0.0 performs an
         exact solve. A small positive tolerance lets the solver treat a
@@ -294,14 +294,14 @@ def solve(A: Matrix, b: Vector, tol: float = 0.0) -> Solution:
             f"A has {A.rows} rows but b has {b.dims} entries."
         )
 
-    matrix_rref = rref(A, tol)
+    matrix_rref = rref(A, tolerance)
     steps = matrix_rref.steps
 
     applied_b = b
     for step in steps:
         applied_b = step.apply(applied_b)
 
-    if _inconsistent_rows(matrix_rref, applied_b, tol):
+    if _inconsistent_rows(matrix_rref, applied_b, tolerance):
         return Solution(A, b, "inconsistent", None, steps)
 
     if matrix_rref.nullity > 0:
@@ -358,7 +358,7 @@ def _eigenvector(matrix: Matrix, eigenvalue: float, n: int) -> Vector | None:
     """
     shifted = matrix - eigenvalue * identity(n)
     scale = max(1.0, max(abs(shifted[i][j]) for i in range(n) for j in range(n)))
-    solution = solve(shifted, zero_vector(n), tol=1e-6 * scale)
+    solution = solve(shifted, zero_vector(n), tolerance=1e-6 * scale)
 
     if solution.null_space is None:
         return None
@@ -368,7 +368,7 @@ def _eigenvector(matrix: Matrix, eigenvalue: float, n: int) -> Vector | None:
 def eigen(
     matrix: Matrix,
     max_iterations: int = 1000,
-    tol: float = 1e-12,
+    tolerance: float = 1e-12,
 ) -> EigenResult:
     """
     Compute the eigenvalues of a square matrix using the QR algorithm.
@@ -379,7 +379,7 @@ def eigen(
     whose diagonal entries are the eigenvalues.
 
     The iteration stops once the strictly-below-diagonal entries sum to less
-    than ``tol`` (recorded as converged), or once ``max_iterations`` is
+    than ``tolerance`` (recorded as converged), or once ``max_iterations`` is
     reached (recorded as not converged). Eigenvalues are the diagonal of the
     final iterate. Eigenvectors are computed separately and are only
     populated when the iteration converges.
@@ -394,7 +394,7 @@ def eigen(
         The square matrix whose eigenvalues will be computed.
     max_iterations : int, optional
         The maximum number of QR iterations to perform. Defaults to 1000.
-    tol : float, optional
+    tolerance : float, optional
         The convergence threshold on the below-diagonal mass. Defaults to
         1e-12.
 
@@ -435,7 +435,7 @@ def eigen(
     converged = False
     iterations = 0
     for iterations in range(1, max_iterations + 1):
-        if _below_diagonal_mass(current) < tol:
+        if _below_diagonal_mass(current) < tolerance:
             converged = True
             iterations -= 1
             break

--- a/panchi/algorithms/reductions.py
+++ b/panchi/algorithms/reductions.py
@@ -11,7 +11,7 @@ from panchi.algorithms.row_operations import (
 
 
 def _find_first_non_zero_row(
-    starting_row_num: int, col_num: int, matrix: Matrix
+    starting_row_num: int, col_num: int, matrix: Matrix, tol: float = 0.0
 ) -> int | None:
     """
     Find the first row at or below starting_row_num with a non-zero entry in col_num.
@@ -24,6 +24,9 @@ def _find_first_non_zero_row(
         The column index to inspect in each row.
     matrix : Matrix
         The matrix to search.
+    tol : float, optional
+        Entries with magnitude at or below this value are treated as zero.
+        The default of 0.0 means exact comparison (only true zeros count).
 
     Returns
     -------
@@ -32,14 +35,14 @@ def _find_first_non_zero_row(
         or None if no such row exists.
     """
     for i in range(starting_row_num, matrix.rows):
-        if matrix[i][col_num] != 0:
+        if abs(matrix[i][col_num]) > tol:
             return i
 
     return None
 
 
 def _swap_pivot(
-    pivot_row: int, pivot_col: int, matrix: Matrix
+    pivot_row: int, pivot_col: int, matrix: Matrix, tol: float = 0.0
 ) -> tuple[Matrix, list[RowOperation]]:
     """
     Swap the pivot row with the first row below it that has a non-zero entry in pivot_col.
@@ -55,6 +58,9 @@ def _swap_pivot(
         The column index of the current pivot position.
     matrix : Matrix
         The matrix to operate on.
+    tol : float, optional
+        Entries with magnitude at or below this value are treated as zero.
+        The default of 0.0 means exact comparison.
 
     Returns
     -------
@@ -64,8 +70,8 @@ def _swap_pivot(
     """
     result = matrix.copy()
     new_operations = []
-    if result[pivot_row][pivot_col] == 0:
-        target_row = _find_first_non_zero_row(pivot_row + 1, pivot_col, result)
+    if abs(result[pivot_row][pivot_col]) <= tol:
+        target_row = _find_first_non_zero_row(pivot_row + 1, pivot_col, result, tol)
         if target_row is not None:
             op = RowSwap(pivot_row, target_row)
             result = op.apply(result)
@@ -75,7 +81,7 @@ def _swap_pivot(
 
 
 def _add_below_pivot(
-    pivot_row: int, pivot_col: int, matrix: Matrix
+    pivot_row: int, pivot_col: int, matrix: Matrix, tol: float = 0.0
 ) -> tuple[Matrix, list[RowOperation]]:
     """
     Eliminate all non-zero entries below the pivot using row addition.
@@ -93,6 +99,9 @@ def _add_below_pivot(
     matrix : Matrix
         The matrix to operate on. The entry at [pivot_row][pivot_col] must
         be non-zero.
+    tol : float, optional
+        Entries with magnitude at or below this value are treated as already
+        zero and skipped. The default of 0.0 means exact comparison.
 
     Returns
     -------
@@ -104,7 +113,7 @@ def _add_below_pivot(
     new_operations = []
     for i in range(pivot_row + 1, result.rows):
         val = result[i][pivot_col]
-        if val == 0:
+        if abs(val) <= tol:
             continue
         op = RowAdd(i, pivot_row, -(val / pivot))
         result = op.apply(result)
@@ -114,7 +123,7 @@ def _add_below_pivot(
 
 
 def _add_above_pivot(
-    pivot_row: int, pivot_col: int, matrix: Matrix
+    pivot_row: int, pivot_col: int, matrix: Matrix, tol: float = 0.0
 ) -> tuple[Matrix, list[RowOperation]]:
     """
     Eliminate all non-zero entries above the pivot using row addition.
@@ -134,6 +143,9 @@ def _add_above_pivot(
     matrix : Matrix
         The matrix to operate on. The entry at [pivot_row][pivot_col] must
         equal 1.
+    tol : float, optional
+        Entries with magnitude at or below this value are treated as already
+        zero and skipped. The default of 0.0 means exact comparison.
 
     Returns
     -------
@@ -145,7 +157,7 @@ def _add_above_pivot(
     new_operations = []
     for i in range(pivot_row - 1, -1, -1):
         val = result[i][pivot_col]
-        if val == 0:
+        if abs(val) <= tol:
             continue
         op = RowAdd(i, pivot_row, -val)
         result = op.apply(result)
@@ -190,7 +202,7 @@ def _scale_pivot(
     return result, new_operations
 
 
-def ref(matrix: Matrix) -> Reduction:
+def ref(matrix: Matrix, tol: float = 0.0) -> Reduction:
     """
     Reduce a matrix to row echelon form using Gaussian elimination.
 
@@ -203,6 +215,13 @@ def ref(matrix: Matrix) -> Reduction:
     ----------
     matrix : Matrix
         The matrix to reduce. Not modified by this function.
+    tol : float, optional
+        Column entries with magnitude at or below this value are treated as
+        zero when selecting pivots, so a column with only near-zero entries
+        becomes a free (non-pivot) column. The default of 0.0 means exact
+        comparison and reproduces the standard exact reduction. A positive
+        tolerance is useful for floating-point matrices that are only
+        approximately rank-deficient (e.g. A - λI for an estimated λ).
 
     Returns
     -------
@@ -231,12 +250,12 @@ def ref(matrix: Matrix) -> Reduction:
     for j in range(matrix.cols):
         if i >= matrix.rows:
             break
-        result, swap_operations = _swap_pivot(i, j, result)
+        result, swap_operations = _swap_pivot(i, j, result, tol)
         operations += swap_operations
-        if result[i][j] == 0:
+        if abs(result[i][j]) <= tol:
             continue
 
-        result, addition_operations = _add_below_pivot(i, j, result)
+        result, addition_operations = _add_below_pivot(i, j, result, tol)
         operations += addition_operations
         pivots.append((i, j))
         i += 1
@@ -244,7 +263,7 @@ def ref(matrix: Matrix) -> Reduction:
     return Reduction(matrix, result, operations, pivots, "REF")
 
 
-def rref(matrix: Matrix) -> Reduction:
+def rref(matrix: Matrix, tol: float = 0.0) -> Reduction:
     """
     Reduce a matrix to reduced row echelon form using Gauss-Jordan elimination.
 
@@ -256,6 +275,10 @@ def rref(matrix: Matrix) -> Reduction:
     ----------
     matrix : Matrix
         The matrix to reduce. Not modified by this function.
+    tol : float, optional
+        Entries with magnitude at or below this value are treated as zero when
+        selecting pivots. The default of 0.0 means exact comparison. See ref()
+        for when a positive tolerance is useful.
 
     Returns
     -------
@@ -278,14 +301,14 @@ def rref(matrix: Matrix) -> Reduction:
     >>> reduction.nullity
     0
     """
-    gaussian_step = ref(matrix)
+    gaussian_step = ref(matrix, tol)
     result = gaussian_step.result
     operations = gaussian_step.steps
     pivots = gaussian_step.pivots
     for i, j in pivots:
         result, scale_operations = _scale_pivot(i, j, result)
         operations += scale_operations
-        result, addition_operations = _add_above_pivot(i, j, result)
+        result, addition_operations = _add_above_pivot(i, j, result, tol)
         operations += addition_operations
 
     return Reduction(matrix, result, operations, pivots, "RREF")

--- a/panchi/algorithms/reductions.py
+++ b/panchi/algorithms/reductions.py
@@ -11,7 +11,7 @@ from panchi.algorithms.row_operations import (
 
 
 def _find_first_non_zero_row(
-    starting_row_num: int, col_num: int, matrix: Matrix, tol: float = 0.0
+    starting_row_num: int, col_num: int, matrix: Matrix, tolerance: float = 0.0
 ) -> int | None:
     """
     Find the first row at or below starting_row_num with a non-zero entry in col_num.
@@ -24,7 +24,7 @@ def _find_first_non_zero_row(
         The column index to inspect in each row.
     matrix : Matrix
         The matrix to search.
-    tol : float, optional
+    tolerance : float, optional
         Entries with magnitude at or below this value are treated as zero.
         The default of 0.0 means exact comparison (only true zeros count).
 
@@ -35,14 +35,14 @@ def _find_first_non_zero_row(
         or None if no such row exists.
     """
     for i in range(starting_row_num, matrix.rows):
-        if abs(matrix[i][col_num]) > tol:
+        if abs(matrix[i][col_num]) > tolerance:
             return i
 
     return None
 
 
 def _swap_pivot(
-    pivot_row: int, pivot_col: int, matrix: Matrix, tol: float = 0.0
+    pivot_row: int, pivot_col: int, matrix: Matrix, tolerance: float = 0.0
 ) -> tuple[Matrix, list[RowOperation]]:
     """
     Swap the pivot row with the first row below it that has a non-zero entry in pivot_col.
@@ -58,7 +58,7 @@ def _swap_pivot(
         The column index of the current pivot position.
     matrix : Matrix
         The matrix to operate on.
-    tol : float, optional
+    tolerance : float, optional
         Entries with magnitude at or below this value are treated as zero.
         The default of 0.0 means exact comparison.
 
@@ -70,8 +70,8 @@ def _swap_pivot(
     """
     result = matrix.copy()
     new_operations = []
-    if abs(result[pivot_row][pivot_col]) <= tol:
-        target_row = _find_first_non_zero_row(pivot_row + 1, pivot_col, result, tol)
+    if abs(result[pivot_row][pivot_col]) <= tolerance:
+        target_row = _find_first_non_zero_row(pivot_row + 1, pivot_col, result, tolerance)
         if target_row is not None:
             op = RowSwap(pivot_row, target_row)
             result = op.apply(result)
@@ -81,7 +81,7 @@ def _swap_pivot(
 
 
 def _add_below_pivot(
-    pivot_row: int, pivot_col: int, matrix: Matrix, tol: float = 0.0
+    pivot_row: int, pivot_col: int, matrix: Matrix, tolerance: float = 0.0
 ) -> tuple[Matrix, list[RowOperation]]:
     """
     Eliminate all non-zero entries below the pivot using row addition.
@@ -99,7 +99,7 @@ def _add_below_pivot(
     matrix : Matrix
         The matrix to operate on. The entry at [pivot_row][pivot_col] must
         be non-zero.
-    tol : float, optional
+    tolerance : float, optional
         Entries with magnitude at or below this value are treated as already
         zero and skipped. The default of 0.0 means exact comparison.
 
@@ -113,7 +113,7 @@ def _add_below_pivot(
     new_operations = []
     for i in range(pivot_row + 1, result.rows):
         val = result[i][pivot_col]
-        if abs(val) <= tol:
+        if abs(val) <= tolerance:
             continue
         op = RowAdd(i, pivot_row, -(val / pivot))
         result = op.apply(result)
@@ -123,7 +123,7 @@ def _add_below_pivot(
 
 
 def _add_above_pivot(
-    pivot_row: int, pivot_col: int, matrix: Matrix, tol: float = 0.0
+    pivot_row: int, pivot_col: int, matrix: Matrix, tolerance: float = 0.0
 ) -> tuple[Matrix, list[RowOperation]]:
     """
     Eliminate all non-zero entries above the pivot using row addition.
@@ -143,7 +143,7 @@ def _add_above_pivot(
     matrix : Matrix
         The matrix to operate on. The entry at [pivot_row][pivot_col] must
         equal 1.
-    tol : float, optional
+    tolerance : float, optional
         Entries with magnitude at or below this value are treated as already
         zero and skipped. The default of 0.0 means exact comparison.
 
@@ -157,7 +157,7 @@ def _add_above_pivot(
     new_operations = []
     for i in range(pivot_row - 1, -1, -1):
         val = result[i][pivot_col]
-        if abs(val) <= tol:
+        if abs(val) <= tolerance:
             continue
         op = RowAdd(i, pivot_row, -val)
         result = op.apply(result)
@@ -202,7 +202,7 @@ def _scale_pivot(
     return result, new_operations
 
 
-def ref(matrix: Matrix, tol: float = 0.0) -> Reduction:
+def ref(matrix: Matrix, tolerance: float = 0.0) -> Reduction:
     """
     Reduce a matrix to row echelon form using Gaussian elimination.
 
@@ -215,7 +215,7 @@ def ref(matrix: Matrix, tol: float = 0.0) -> Reduction:
     ----------
     matrix : Matrix
         The matrix to reduce. Not modified by this function.
-    tol : float, optional
+    tolerance : float, optional
         Column entries with magnitude at or below this value are treated as
         zero when selecting pivots, so a column with only near-zero entries
         becomes a free (non-pivot) column. The default of 0.0 means exact
@@ -250,12 +250,12 @@ def ref(matrix: Matrix, tol: float = 0.0) -> Reduction:
     for j in range(matrix.cols):
         if i >= matrix.rows:
             break
-        result, swap_operations = _swap_pivot(i, j, result, tol)
+        result, swap_operations = _swap_pivot(i, j, result, tolerance)
         operations += swap_operations
-        if abs(result[i][j]) <= tol:
+        if abs(result[i][j]) <= tolerance:
             continue
 
-        result, addition_operations = _add_below_pivot(i, j, result, tol)
+        result, addition_operations = _add_below_pivot(i, j, result, tolerance)
         operations += addition_operations
         pivots.append((i, j))
         i += 1
@@ -263,7 +263,7 @@ def ref(matrix: Matrix, tol: float = 0.0) -> Reduction:
     return Reduction(matrix, result, operations, pivots, "REF")
 
 
-def rref(matrix: Matrix, tol: float = 0.0) -> Reduction:
+def rref(matrix: Matrix, tolerance: float = 0.0) -> Reduction:
     """
     Reduce a matrix to reduced row echelon form using Gauss-Jordan elimination.
 
@@ -275,7 +275,7 @@ def rref(matrix: Matrix, tol: float = 0.0) -> Reduction:
     ----------
     matrix : Matrix
         The matrix to reduce. Not modified by this function.
-    tol : float, optional
+    tolerance : float, optional
         Entries with magnitude at or below this value are treated as zero when
         selecting pivots. The default of 0.0 means exact comparison. See ref()
         for when a positive tolerance is useful.
@@ -301,14 +301,14 @@ def rref(matrix: Matrix, tol: float = 0.0) -> Reduction:
     >>> reduction.nullity
     0
     """
-    gaussian_step = ref(matrix, tol)
+    gaussian_step = ref(matrix, tolerance)
     result = gaussian_step.result
     operations = gaussian_step.steps
     pivots = gaussian_step.pivots
     for i, j in pivots:
         result, scale_operations = _scale_pivot(i, j, result)
         operations += scale_operations
-        result, addition_operations = _add_above_pivot(i, j, result, tol)
+        result, addition_operations = _add_above_pivot(i, j, result, tolerance)
         operations += addition_operations
 
     return Reduction(matrix, result, operations, pivots, "RREF")

--- a/panchi/algorithms/results.py
+++ b/panchi/algorithms/results.py
@@ -280,15 +280,100 @@ class LUDecomposition:
 
 
 class QRDecomposition:
+    """
+    The result of a (thin) QR decomposition via Gram-Schmidt.
+
+    Stores the original matrix, the matrix Q with orthonormal columns, the
+    upper triangular matrix R, and the ordered list of Gram-Schmidt steps
+    used to build Q. The decomposition satisfies original == Q @ R.
+
+    Q is formed by orthonormalizing the columns of the original matrix, so
+    its columns are an orthonormal basis for the column space. R = Qᵀ @ A is
+    upper triangular and its diagonal entries record how much of each column
+    survived orthogonalization. The recorded steps expose the column-by-column
+    derivation of Q, mirroring how a Reduction exposes its row operations.
+
+    Parameters
+    ----------
+    original : Matrix
+        The matrix that was decomposed, with linearly independent columns.
+    q : Matrix
+        The matrix with orthonormal columns.
+    r : Matrix
+        The upper triangular matrix satisfying original == q @ r.
+    steps : list[GramSchmidtStep]
+        The ordered Gram-Schmidt steps, one per column, used to build Q.
+
+    Examples
+    --------
+    >>> A = Matrix([[1, 0], [0, 1]])
+    >>> decomp = qr_decomposition(A)
+    >>> decomp.q @ decomp.r == A
+    True
+    """
+
     def __init__(
         self,
         original: Matrix,
         q: Matrix,
         r: Matrix,
+        steps: list,
     ) -> None:
         self.original = original
         self.q = q
         self.r = r
+        self.steps = steps
+
+    def __str__(self) -> str:
+        """
+        Return a readable summary of the QR decomposition.
+
+        Shows the column-by-column Gram-Schmidt walkthrough, then Q and R
+        individually, and states the factorisation relationship A = Q @ R.
+
+        Returns
+        -------
+        str
+            Human-readable decomposition summary.
+        """
+        header: str = (
+            f"QR decomposition of "
+            f"{self.original.rows}×{self.original.cols} matrix"
+            f" — {len(self.steps)} steps\n"
+        )
+
+        steps_str: str = ""
+        for step in self.steps:
+            steps_str += f"\n{step}\n"
+
+        body: str = (
+            f"\nA = Q @ R\n"
+            f"\nA:\n{self.original}\n"
+            f"\nQ:\n{self.q}\n"
+            f"\nR:\n{self.r}"
+        )
+
+        return header + steps_str + body
+
+    def __repr__(self) -> str:
+        """
+        Return a concise data inspection string for this QRDecomposition.
+
+        Returns
+        -------
+        str
+            Compact representation showing shape and number of steps.
+
+        Examples
+        --------
+        >>> qr_decomposition(Matrix([[1, 0], [0, 1]]))
+        QRDecomposition(shape=2×2, steps=2)
+        """
+        return (
+            f"QRDecomposition("
+            f"shape={self.original.rows}×{self.original.cols}, "
+            f"steps={len(self.steps)})"
+        )
 
 
 class InverseResult:

--- a/panchi/algorithms/results.py
+++ b/panchi/algorithms/results.py
@@ -279,6 +279,18 @@ class LUDecomposition:
         )
 
 
+class QRDecomposition:
+    def __init__(
+        self,
+        original: Matrix,
+        q: Matrix,
+        r: Matrix,
+    ) -> None:
+        self.original = original
+        self.q = q
+        self.r = r
+
+
 class InverseResult:
     """
     The result of a matrix inversion via Gauss-Jordan elimination.

--- a/panchi/algorithms/results.py
+++ b/panchi/algorithms/results.py
@@ -605,3 +605,124 @@ class Solution:
             f"status={self.status}, "
             f"solution={self.solution})"
         )
+
+
+class EigenResult:
+    """
+    The result of an eigenvalue computation via the QR algorithm.
+
+    Stores the original matrix, the computed eigenvalues, the corresponding
+    eigenvectors, and metadata about the iterative process: how many
+    iterations were run, whether the iteration converged, and the final
+    (near) upper-triangular matrix the QR algorithm produced.
+
+    Eigenvalues are read off the diagonal of the QR iterate, and each
+    eigenvector is paired with the eigenvalue at the same index. The values
+    are numerical approximations, not exact or symbolic results.
+
+    Only real eigenvalues are supported. Matrices with complex eigenvalues
+    (or eigenvalues of equal magnitude) may not converge; in that case
+    ``converged`` is False and ``eigenvectors`` is empty.
+
+    Parameters
+    ----------
+    original : Matrix
+        The square matrix whose spectrum was computed.
+    eigenvalues : list[float]
+        The computed eigenvalues, in the order they appear on the diagonal
+        of the final iterate.
+    eigenvectors : list[Vector]
+        The eigenvectors, paired by index with eigenvalues. Empty when the
+        iteration did not converge.
+    iterations : int
+        The number of QR iterations performed.
+    converged : bool
+        Whether the below-diagonal mass fell below the tolerance before the
+        iteration limit was reached.
+    triangular : Matrix
+        The final (near) upper-triangular matrix produced by the iteration.
+
+    Examples
+    --------
+    >>> result = eigen(Matrix([[2, 1], [1, 2]]))
+    >>> sorted(round(v, 6) for v in result.eigenvalues)
+    [1.0, 3.0]
+    """
+
+    def __init__(
+        self,
+        original: Matrix,
+        eigenvalues: list[float],
+        eigenvectors: list[Vector],
+        iterations: int,
+        converged: bool,
+        triangular: Matrix,
+    ) -> None:
+        self.original = original
+        self.eigenvalues = eigenvalues
+        self.eigenvectors = eigenvectors
+        self.iterations = iterations
+        self.converged = converged
+        self.triangular = triangular
+
+    @property
+    def pairs(self) -> list[tuple[float, Vector]]:
+        """
+        The eigenvalue/eigenvector pairs, zipped by index.
+
+        Returns
+        -------
+        list[tuple[float, Vector]]
+            One (eigenvalue, eigenvector) tuple per computed eigenvector.
+            Empty when no eigenvectors were computed.
+        """
+        return list(zip(self.eigenvalues, self.eigenvectors))
+
+    def __str__(self) -> str:
+        """
+        Return a readable summary of the eigenvalue computation.
+
+        Shows the iteration count and convergence status, then each
+        eigenvalue together with its eigenvector when available.
+
+        Returns
+        -------
+        str
+            Human-readable eigendecomposition summary.
+        """
+        header: str = (
+            f"Eigendecomposition of "
+            f"{self.original.rows}×{self.original.cols} matrix"
+            f" — {self.iterations} iterations (converged: {self.converged})\n"
+        )
+
+        if self.eigenvectors:
+            body = "\n" + "\n".join(
+                f"λ = {value}\n  v = {vector}" for value, vector in self.pairs
+            )
+        else:
+            body = "\nEigenvalues: " + ", ".join(str(v) for v in self.eigenvalues)
+
+        return header + body
+
+    def __repr__(self) -> str:
+        """
+        Return a concise data inspection string for this EigenResult.
+
+        Returns
+        -------
+        str
+            Compact representation showing shape, iteration count, and
+            convergence status.
+
+        Examples
+        --------
+        >>> eigen(Matrix([[2, 1], [1, 2]]))
+        EigenResult(shape=2×2, iterations=..., converged=True)
+        """
+        return (
+            f"EigenResult("
+            f"shape={self.original.rows}×{self.original.cols}, "
+            f"iterations={self.iterations}, "
+            f"converged={self.converged})"
+        )

--- a/panchi/algorithms/vector_operations.py
+++ b/panchi/algorithms/vector_operations.py
@@ -161,14 +161,86 @@ def orthogonal_complement(space: VectorSpace) -> VectorSpace:
 
 
 def vector_projection(projected_vector: Vector, axis_vector: Vector) -> Vector:
+    """
+    Project one vector orthogonally onto the line spanned by another.
+
+    The projection of v onto a is the component of v that lies along a,
+    computed as (v . a) / (a . a) * a. It is the closest point to v on the
+    line through the origin in the direction of a.
+
+    Parameters
+    ----------
+    projected_vector : Vector
+        The vector being projected (v).
+    axis_vector : Vector
+        The vector defining the direction to project onto (a). Must be
+        non-zero.
+
+    Returns
+    -------
+    Vector
+        The projection of projected_vector onto axis_vector.
+
+    Raises
+    ------
+    ValueError
+        If the vectors have different dimensions.
+    ZeroDivisionError
+        If axis_vector is the zero vector.
+
+    Examples
+    --------
+    >>> v = Vector([2, 3])
+    >>> a = Vector([1, 0])
+    >>> print(vector_projection(v, a))
+    [2.0, 0.0]
+    """
     scalar_projection = dot(projected_vector, axis_vector) / dot(axis_vector, axis_vector)
     return scalar_projection * axis_vector
 
 
-# TODO: Decide if this is a smart file to keep gram schmidt in
-def gram_schmidt_algorithm(vectors: list[Vector]) -> list[Vector]:
+def gram_schmidt(vectors: list[Vector]) -> list[Vector]:
+    """
+    Orthonormalize a list of vectors using the Gram-Schmidt process.
+
+    Given a list of linearly independent vectors, produces an orthonormal
+    list spanning the same subspace: each output vector has unit length and
+    is orthogonal to all the others. Each input vector has its components
+    along the previously produced directions removed, and the remainder is
+    normalized.
+
+    Parameters
+    ----------
+    vectors : list[Vector]
+        The vectors to orthonormalize. Must be non-empty; the vectors are
+        expected to be linearly independent.
+
+    Returns
+    -------
+    list[Vector]
+        An orthonormal list of vectors spanning the same subspace, in the
+        same order as the inputs.
+
+    Raises
+    ------
+    ValueError
+        If vectors is empty.
+    ZeroDivisionError
+        If the vectors are linearly dependent (a vector reduces to the zero
+        vector and cannot be normalized).
+
+    Examples
+    --------
+    >>> a = Vector([1, 1, 0])
+    >>> b = Vector([1, 0, 1])
+    >>> q = gram_schmidt([a, b])
+    >>> round(dot(q[0], q[1]), 10)
+    0.0
+    >>> round(q[0].magnitude, 10)
+    1.0
+    """
     if not vectors:
-        raise ValueError
+        raise ValueError("gram_schmidt() requires at least one vector.")
 
     n = len(vectors)
     orthogonal_vectors = []

--- a/panchi/algorithms/vector_operations.py
+++ b/panchi/algorithms/vector_operations.py
@@ -199,6 +199,82 @@ def vector_projection(projected_vector: Vector, axis_vector: Vector) -> Vector:
     return scalar_projection * axis_vector
 
 
+class GramSchmidtStep:
+    """
+    The derivation of a single orthonormal vector in Gram-Schmidt.
+
+    Records, for one input vector, the projections that were removed to make
+    it orthogonal to the previously produced directions, the resulting
+    orthogonal vector before normalization, and the final unit vector.
+
+    Parameters
+    ----------
+    index : int
+        The position of this vector in the input list (0-based).
+    original : Vector
+        The input vector this step started from.
+    projections : list[Vector]
+        The projections onto each previously produced orthogonal vector,
+        subtracted in order, that were removed from original.
+    orthogonal : Vector
+        The orthogonalized vector, before normalization.
+    orthonormal : Vector
+        The final unit vector (orthogonal normalized to length 1).
+    """
+
+    def __init__(
+        self,
+        index: int,
+        original: Vector,
+        projections: list[Vector],
+        orthogonal: Vector,
+        orthonormal: Vector,
+    ) -> None:
+        self.index = index
+        self.original = original
+        self.projections = projections
+        self.orthogonal = orthogonal
+        self.orthonormal = orthonormal
+
+    def __str__(self) -> str:
+        lines = [f"Step {self.index + 1}: v{self.index} = {self.original}"]
+        for j, projection in enumerate(self.projections):
+            lines.append(f"  remove projection onto q{j}: {projection}")
+        lines.append(f"  orthogonal: {self.orthogonal}")
+        lines.append(f"  normalize -> q{self.index}: {self.orthonormal}")
+        return "\n".join(lines)
+
+
+def _gram_schmidt_steps(vectors: list[Vector]) -> list[GramSchmidtStep]:
+    """
+    Run Gram-Schmidt, recording the derivation of each orthonormal vector.
+
+    Shared internal implementation behind gram_schmidt (which keeps only the
+    final orthonormal vectors) and qr_decomposition (which keeps the full
+    step-by-step walkthrough).
+    """
+    if not vectors:
+        raise ValueError("gram_schmidt() requires at least one vector.")
+
+    steps: list[GramSchmidtStep] = []
+    orthogonal_vectors: list[Vector] = []
+    for i, vector in enumerate(vectors):
+        orthogonal_vector = vector
+        projections: list[Vector] = []
+        for previous in orthogonal_vectors:
+            projection = vector_projection(vector, previous)
+            projections.append(projection)
+            orthogonal_vector -= projection
+
+        orthogonal_vectors.append(orthogonal_vector)
+        orthonormal = orthogonal_vector.normalize()
+        steps.append(
+            GramSchmidtStep(i, vector, projections, orthogonal_vector, orthonormal)
+        )
+
+    return steps
+
+
 def gram_schmidt(vectors: list[Vector]) -> list[Vector]:
     """
     Orthonormalize a list of vectors using the Gram-Schmidt process.
@@ -239,16 +315,4 @@ def gram_schmidt(vectors: list[Vector]) -> list[Vector]:
     >>> round(q[0].magnitude, 10)
     1.0
     """
-    if not vectors:
-        raise ValueError("gram_schmidt() requires at least one vector.")
-
-    n = len(vectors)
-    orthogonal_vectors = []
-    for i in range(n):
-        orthogonal_vector = vectors[i]
-        for j in range(i):
-            orthogonal_vector -= vector_projection(vectors[i], orthogonal_vectors[j])
-
-        orthogonal_vectors.append(orthogonal_vector)
-
-    return [v.normalize() for v in orthogonal_vectors]
+    return [step.orthonormal for step in _gram_schmidt_steps(vectors)]

--- a/panchi/algorithms/vector_operations.py
+++ b/panchi/algorithms/vector_operations.py
@@ -158,3 +158,25 @@ def orthogonal_complement(space: VectorSpace) -> VectorSpace:
         null_vectors.append(Vector(components))
 
     return VectorSpace(null_vectors)
+
+
+def vector_projection(projected_vector: Vector, axis_vector: Vector) -> Vector:
+    scalar_projection = dot(projected_vector, axis_vector) / dot(axis_vector, axis_vector)
+    return scalar_projection * axis_vector
+
+
+# TODO: Decide if this is a smart file to keep gram schmidt in
+def gram_schmidt_algorithm(vectors: list[Vector]) -> list[Vector]:
+    if not vectors:
+        raise ValueError
+
+    n = len(vectors)
+    orthogonal_vectors = []
+    for i in range(n):
+        orthogonal_vector = vectors[i]
+        for j in range(i):
+            orthogonal_vector -= vector_projection(vectors[i], orthogonal_vectors[j])
+
+        orthogonal_vectors.append(orthogonal_vector)
+
+    return [v.normalize() for v in orthogonal_vectors]

--- a/panchi/primitives/factories.py
+++ b/panchi/primitives/factories.py
@@ -468,6 +468,7 @@ def rotation_matrix_3d(
 
     return Matrix([row_1, row_2, row_3])
 
+
 def exact_vector(data: list) -> Vector:
     """
     Create a Vector with all elements converted to Fraction for exact arithmetic.
@@ -527,21 +528,63 @@ def exact_matrix(data: list[list]) -> Matrix:
      [3, 4]]
     """
     return Matrix(
-        [[Fraction(x) if not isinstance(x, Fraction) else x for x in row] for row in data]
+        [
+            [Fraction(x) if not isinstance(x, Fraction) else x for x in row]
+            for row in data
+        ]
     )
 
 
 def vector_column_matrix(vectors: list[Vector]) -> Matrix:
-    # Add type guard
+    """
+    Build a Matrix whose columns are the given vectors.
+
+    Each vector becomes one column, in order, so the resulting matrix has
+    as many rows as the vectors' shared dimension and as many columns as
+    there are vectors. This is the natural way to assemble a matrix from a
+    set of column vectors, such as the orthonormal basis produced by
+    Gram-Schmidt when forming Q in a QR decomposition.
+
+    Parameters
+    ----------
+    vectors : list[Vector]
+        The vectors to place as columns. Must be non-empty and all share
+        the same dimension.
+
+    Returns
+    -------
+    Matrix
+        A matrix with the given vectors as its columns.
+
+    Raises
+    ------
+    ValueError
+        If vectors is empty, or if the vectors do not all share the same
+        dimension.
+
+    Examples
+    --------
+    >>> a = Vector([1, 2, 3])
+    >>> b = Vector([4, 5, 6])
+    >>> print(vector_column_matrix([a, b]))
+    [[1, 4],
+     [2, 5],
+     [3, 6]]
+    """
+    if not vectors:
+        raise ValueError("vector_column_matrix() requires at least one vector.")
+
     num_vectors = len(vectors)
     for i in range(num_vectors):
         for j in range(i + 1, num_vectors):
             if vectors[i].dims != vectors[j].dims:
-                raise ValueError("")
+                raise ValueError(
+                    f"All vectors must share the same dimension. "
+                    f"Got {vectors[i].dims} and {vectors[j].dims}."
+                )
 
     result = []
     for vector in vectors:
         result.append(vector.to_list())
 
     return Matrix(result).T
-

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "panchi"
-version = "1.1.0"
+version = "1.2.0"
 description = "A Python-native linear algebra library for learning, experimentation, and visual intuition"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -68,6 +68,42 @@ class TestEigenvalueCorrectness:
         )
 
 
+class TestEigenvectorCorrectness:
+    """Test that computed eigenvectors satisfy A @ v == λ * v."""
+
+    def _assert_eigenpairs(self, matrix):
+        result = eigen(matrix)
+        assert len(result.eigenvectors) == matrix.rows
+        for value, vector in result.pairs:
+            av = matrix @ vector
+            lv = value * vector
+            for i in range(vector.dims):
+                assert av[i] == pytest.approx(lv[i], abs=1e-6)
+
+    def test_symmetric_2x2_eigenpairs(self):
+        self._assert_eigenpairs(Matrix([[2, 1], [1, 2]]))
+
+    def test_symmetric_3x3_eigenpairs(self):
+        self._assert_eigenpairs(Matrix([[2, 0, 0], [0, 3, 4], [0, 4, 9]]))
+
+    def test_non_symmetric_eigenpairs(self):
+        self._assert_eigenpairs(Matrix([[2, 1], [0, 3]]))
+
+    def test_eigenvectors_are_unit_length(self):
+        result = eigen(Matrix([[2, 1], [1, 2]]))
+        for vector in result.eigenvectors:
+            assert vector.magnitude == pytest.approx(1.0, abs=1e-9)
+
+    def test_pairs_align_values_and_vectors(self):
+        result = eigen(Matrix([[2, 1], [1, 2]]))
+        assert result.pairs == list(zip(result.eigenvalues, result.eigenvectors))
+
+    def test_str_lists_eigenvectors_when_present(self):
+        text = str(eigen(Matrix([[2, 1], [1, 2]])))
+        assert "λ =" in text
+        assert "v =" in text
+
+
 class TestEigenConvergence:
     """Test convergence reporting for non-convergent matrices."""
 

--- a/tests/test_eigen.py
+++ b/tests/test_eigen.py
@@ -1,0 +1,81 @@
+import math
+
+import pytest
+
+from panchi import Matrix, eigen, determinant_lu
+from panchi.algorithms import EigenResult
+
+
+def _sorted_round(values, digits=6):
+    return sorted(round(v, digits) for v in values)
+
+
+class TestEigenValidation:
+    """Test input validation for eigen()."""
+
+    def test_non_matrix_raises_type_error(self):
+        with pytest.raises(TypeError):
+            eigen("not a matrix")
+
+    def test_non_square_raises_value_error(self):
+        with pytest.raises(ValueError):
+            eigen(Matrix([[1, 2, 3], [4, 5, 6]]))
+
+
+class TestEigenResultObject:
+    """Test the EigenResult object's structure and attributes."""
+
+    def test_returns_eigen_result_instance(self):
+        assert isinstance(eigen(Matrix([[2, 1], [1, 2]])), EigenResult)
+
+    def test_original_is_preserved(self):
+        m = Matrix([[2, 1], [1, 2]])
+        assert eigen(m).original == m
+
+    def test_converges_for_symmetric_matrix(self):
+        assert eigen(Matrix([[2, 1], [1, 2]])).converged is True
+
+    def test_eigenvalue_count_matches_dimension(self):
+        assert len(eigen(Matrix([[2, 1], [1, 2]])).eigenvalues) == 2
+
+
+class TestEigenvalueCorrectness:
+    """Test the numerical correctness of the computed eigenvalues."""
+
+    def test_diagonal_matrix(self):
+        result = eigen(Matrix([[2, 0], [0, 3]]))
+        assert _sorted_round(result.eigenvalues) == [2.0, 3.0]
+
+    def test_symmetric_2x2(self):
+        result = eigen(Matrix([[2, 1], [1, 2]]))
+        assert _sorted_round(result.eigenvalues) == [1.0, 3.0]
+
+    def test_symmetric_3x3(self):
+        # Eigenvalues of [[2,0,0],[0,3,4],[0,4,9]] are 2, 1, 11.
+        result = eigen(Matrix([[2, 0, 0], [0, 3, 4], [0, 4, 9]]))
+        assert _sorted_round(result.eigenvalues) == [1.0, 2.0, 11.0]
+
+    def test_sum_of_eigenvalues_equals_trace(self):
+        m = Matrix([[4, 1], [2, 3]])
+        result = eigen(m)
+        assert sum(result.eigenvalues) == pytest.approx(m.trace, abs=1e-6)
+
+    def test_product_of_eigenvalues_equals_determinant(self):
+        m = Matrix([[4, 1], [2, 3]])
+        result = eigen(m)
+        assert math.prod(result.eigenvalues) == pytest.approx(
+            determinant_lu(m), abs=1e-6
+        )
+
+
+class TestEigenConvergence:
+    """Test convergence reporting for non-convergent matrices."""
+
+    def test_rotation_matrix_does_not_converge(self):
+        # A 90° rotation has complex eigenvalues; unshifted QR will not settle.
+        result = eigen(Matrix([[0, -1], [1, 0]]), max_iterations=200)
+        assert result.converged is False
+
+    def test_non_converged_has_no_eigenvectors(self):
+        result = eigen(Matrix([[0, -1], [1, 0]]), max_iterations=200)
+        assert result.eigenvectors == []

--- a/tests/test_gram_schmidt.py
+++ b/tests/test_gram_schmidt.py
@@ -1,0 +1,59 @@
+import pytest
+
+from panchi import Vector, dot, gram_schmidt, vector_projection
+
+
+class TestVectorProjection:
+    """Test cases for orthogonal projection of one vector onto another."""
+
+    def test_projection_onto_axis(self):
+        v = Vector([2, 3])
+        a = Vector([1, 0])
+        assert vector_projection(v, a).to_list() == pytest.approx([2.0, 0.0])
+
+    def test_projection_onto_non_unit_axis(self):
+        # Projecting onto a non-unit vector must divide by (a . a), not |a|.
+        v = Vector([1, 0])
+        a = Vector([2, 0])
+        assert vector_projection(v, a).to_list() == pytest.approx([1.0, 0.0])
+
+    def test_orthogonal_projection_is_zero(self):
+        v = Vector([0, 5])
+        a = Vector([1, 0])
+        assert vector_projection(v, a).to_list() == pytest.approx([0.0, 0.0])
+
+    def test_dimension_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            vector_projection(Vector([1, 2]), Vector([1, 2, 3]))
+
+
+class TestGramSchmidt:
+    """Test cases for Gram-Schmidt orthonormalization."""
+
+    def test_result_is_orthonormal(self):
+        q = gram_schmidt([Vector([1, 1, 0]), Vector([1, 0, 1]), Vector([0, 1, 1])])
+        for i in range(len(q)):
+            assert q[i].magnitude == pytest.approx(1.0, abs=1e-9)
+            for j in range(i + 1, len(q)):
+                assert dot(q[i], q[j]) == pytest.approx(0.0, abs=1e-9)
+
+    def test_preserves_count(self):
+        q = gram_schmidt([Vector([1, 1, 0]), Vector([1, 0, 1])])
+        assert len(q) == 2
+
+    def test_already_orthonormal_is_preserved(self):
+        q = gram_schmidt([Vector([1, 0]), Vector([0, 1])])
+        assert q[0].to_list() == pytest.approx([1.0, 0.0])
+        assert q[1].to_list() == pytest.approx([0.0, 1.0])
+
+    def test_single_vector_is_normalized(self):
+        q = gram_schmidt([Vector([3, 4])])
+        assert q[0].to_list() == pytest.approx([0.6, 0.8])
+
+    def test_empty_raises_value_error(self):
+        with pytest.raises(ValueError):
+            gram_schmidt([])
+
+    def test_linearly_dependent_raises(self):
+        with pytest.raises(ZeroDivisionError):
+            gram_schmidt([Vector([1, 0]), Vector([2, 0])])

--- a/tests/test_matrix_algorithms.py
+++ b/tests/test_matrix_algorithms.py
@@ -685,3 +685,43 @@ class TestRref:
     def test_rref_original_is_preserved(self):
         m = Matrix([[1, 2], [3, 4]])
         assert rref(m).original == m
+
+
+class TestReductionTolerance:
+    """Test the optional tolerance parameter on ref() and rref()."""
+
+    # Only approximately rank 1: forward elimination leaves a ~1e-12 residual
+    # pivot, so exact reduction reports rank 2 but a tolerance collapses it.
+    NEAR_DEPENDENT = Matrix([[1.0, 1.0], [1.0, 1.0 + 1e-12]])
+
+    def test_ref_default_is_exact(self):
+        # Under exact comparison the tiny residual counts as a pivot.
+        assert ref(self.NEAR_DEPENDENT).rank == 2
+
+    def test_ref_tolerance_treats_near_zero_pivot_as_free(self):
+        assert ref(self.NEAR_DEPENDENT, tolerance=1e-6).rank == 1
+
+    def test_rref_default_is_exact(self):
+        assert rref(self.NEAR_DEPENDENT).rank == 2
+
+    def test_rref_tolerance_treats_near_zero_pivot_as_free(self):
+        reduction = rref(self.NEAR_DEPENDENT, tolerance=1e-6)
+        assert reduction.rank == 1
+        assert reduction.nullity == 1
+
+    def test_zero_tolerance_matches_default(self):
+        # Passing tolerance=0.0 explicitly must equal the default exact call.
+        m = Matrix([[2, 4, 1], [0, 0, 5], [1, 2, 3]])
+        assert rref(m, tolerance=0.0).result == rref(m).result
+        assert ref(m, tolerance=0.0).pivots == ref(m).pivots
+
+    def test_tolerance_does_not_disturb_genuine_pivots(self):
+        # A well-conditioned full-rank matrix keeps all pivots under a small
+        # tolerance — real pivots are far larger than the tolerance.
+        m = Matrix([[3.0, 1.0], [1.0, 3.0]])
+        assert ref(m, tolerance=1e-6).rank == 2
+
+    def test_tolerance_detects_exactly_singular_matrix(self):
+        # Genuinely rank-deficient matrices reduce identically with tolerance.
+        m = Matrix([[1.0, 2.0], [2.0, 4.0]])
+        assert rref(m, tolerance=1e-9).rank == 1

--- a/tests/test_matrix_operations.py
+++ b/tests/test_matrix_operations.py
@@ -412,7 +412,7 @@ class TestSolveTolerance:
     def test_tolerance_detects_near_singular(self):
         # With a tolerance, the tiny pivot is treated as zero → infinite solutions.
         A = Matrix([[1.0, 1.0], [1.0, 1.0 + 1e-12]])
-        result = solve(A, Vector([0.0, 0.0]), tol=1e-6)
+        result = solve(A, Vector([0.0, 0.0]), tolerance=1e-6)
         assert result.status == "infinite"
         assert result.null_space is not None
         assert result.null_space.dims == 1
@@ -422,7 +422,7 @@ class TestSolveTolerance:
         A = Matrix([[2, 1], [5, 3]])
         b = Vector([1, 2])
         exact = solve(A, b)
-        toleranced = solve(A, b, tol=1e-9)
+        toleranced = solve(A, b, tolerance=1e-9)
         assert toleranced.status == exact.status == "unique"
         for i in range(b.dims):
             assert toleranced.solution[i] == pytest.approx(exact.solution[i], abs=1e-12)

--- a/tests/test_matrix_operations.py
+++ b/tests/test_matrix_operations.py
@@ -397,3 +397,32 @@ class TestSolveInfinite:
         s = str(result)
         assert "t1·" in s
         assert "t4·" in s
+
+
+class TestSolveTolerance:
+    """Test the optional tolerance flag on solve()."""
+
+    def test_default_is_exact(self):
+        # An approximately-singular matrix is full-rank under exact comparison.
+        A = Matrix([[1.0, 1.0], [1.0, 1.0 + 1e-12]])
+        result = solve(A, Vector([0.0, 0.0]))
+        assert result.status == "unique"
+        assert result.null_space is None
+
+    def test_tolerance_detects_near_singular(self):
+        # With a tolerance, the tiny pivot is treated as zero → infinite solutions.
+        A = Matrix([[1.0, 1.0], [1.0, 1.0 + 1e-12]])
+        result = solve(A, Vector([0.0, 0.0]), tol=1e-6)
+        assert result.status == "infinite"
+        assert result.null_space is not None
+        assert result.null_space.dims == 1
+
+    def test_tolerance_does_not_change_exact_systems(self):
+        # A genuinely non-singular system solves the same with a small tolerance.
+        A = Matrix([[2, 1], [5, 3]])
+        b = Vector([1, 2])
+        exact = solve(A, b)
+        toleranced = solve(A, b, tol=1e-9)
+        assert toleranced.status == exact.status == "unique"
+        for i in range(b.dims):
+            assert toleranced.solution[i] == pytest.approx(exact.solution[i], abs=1e-12)

--- a/tests/test_qr_decomposition.py
+++ b/tests/test_qr_decomposition.py
@@ -1,0 +1,71 @@
+import pytest
+
+from panchi import Matrix, qr_decomposition
+from panchi.algorithms import QRDecomposition
+
+
+class TestQRDecompositionProperties:
+    """Test the QRDecomposition result object's structure and attributes."""
+
+    def test_returns_qr_decomposition_instance(self):
+        m = Matrix([[1, 1, 0], [1, 0, 1], [0, 1, 1]])
+        assert isinstance(qr_decomposition(m), QRDecomposition)
+
+    def test_original_is_preserved(self):
+        m = Matrix([[1, 1, 0], [1, 0, 1], [0, 1, 1]])
+        assert qr_decomposition(m).original == m
+
+    def test_step_count_matches_columns(self):
+        m = Matrix([[1, 1, 0], [1, 0, 1], [0, 1, 1]])
+        assert len(qr_decomposition(m).steps) == m.cols
+
+    def test_q_and_r_have_correct_shape(self):
+        m = Matrix([[1, 1, 0], [1, 0, 1], [0, 1, 1]])
+        decomp = qr_decomposition(m)
+        assert decomp.q.shape == (3, 3)
+        assert decomp.r.shape == (3, 3)
+
+
+class TestQRDecompositionCorrectness:
+    """Test the mathematical correctness of the QR factorisation."""
+
+    def test_reconstruction(self):
+        m = Matrix([[1, 1, 0], [1, 0, 1], [0, 1, 1]])
+        decomp = qr_decomposition(m)
+        product = decomp.q @ decomp.r
+        for i in range(m.rows):
+            for j in range(m.cols):
+                assert product[i][j] == pytest.approx(m[i][j], abs=1e-9)
+
+    def test_q_has_orthonormal_columns(self):
+        m = Matrix([[1, 1, 0], [1, 0, 1], [0, 1, 1]])
+        q = qr_decomposition(m).q
+        gram = q.T @ q
+        for i in range(q.cols):
+            for j in range(q.cols):
+                assert gram[i][j] == pytest.approx(1 if i == j else 0, abs=1e-9)
+
+    def test_r_is_upper_triangular(self):
+        m = Matrix([[1, 1, 0], [1, 0, 1], [0, 1, 1]])
+        r = qr_decomposition(m).r
+        for i in range(1, r.rows):
+            for j in range(i):
+                assert r[i][j] == pytest.approx(0, abs=1e-9)
+
+    def test_identity_decomposes_to_identity(self):
+        decomp = qr_decomposition(Matrix([[1, 0], [0, 1]]))
+        assert decomp.q @ decomp.r == Matrix([[1, 0], [0, 1]])
+
+
+class TestQRDecompositionDisplay:
+    """Test the string representations of QRDecomposition."""
+
+    def test_repr_is_compact(self):
+        decomp = qr_decomposition(Matrix([[1, 0], [0, 1]]))
+        assert repr(decomp) == "QRDecomposition(shape=2×2, steps=2)"
+
+    def test_str_mentions_relationship_and_steps(self):
+        text = str(qr_decomposition(Matrix([[1, 1], [0, 1]])))
+        assert "A = Q @ R" in text
+        assert "Step 1" in text
+        assert "normalize" in text

--- a/tests/test_vector_column_matrix.py
+++ b/tests/test_vector_column_matrix.py
@@ -1,0 +1,36 @@
+import pytest
+
+from panchi import Vector, Matrix, vector_column_matrix
+
+
+class TestVectorColumnMatrix:
+    """Test cases for assembling a matrix from column vectors."""
+
+    def test_columns_match_input_vectors(self):
+        a = Vector([1, 2, 3])
+        b = Vector([4, 5, 6])
+        m = vector_column_matrix([a, b])
+        assert m.col_vectors[0].to_list() == [1, 2, 3]
+        assert m.col_vectors[1].to_list() == [4, 5, 6]
+
+    def test_shape_is_dims_by_count(self):
+        a = Vector([1, 2, 3])
+        b = Vector([4, 5, 6])
+        assert vector_column_matrix([a, b]).shape == (3, 2)
+
+    def test_single_vector_is_single_column(self):
+        m = vector_column_matrix([Vector([1, 2])])
+        assert m.shape == (2, 1)
+        assert m.col_vectors[0].to_list() == [1, 2]
+
+    def test_result_is_matrix(self):
+        m = vector_column_matrix([Vector([1, 2]), Vector([3, 4])])
+        assert isinstance(m, Matrix)
+
+    def test_empty_list_raises_value_error(self):
+        with pytest.raises(ValueError):
+            vector_column_matrix([])
+
+    def test_dimension_mismatch_raises_value_error(self):
+        with pytest.raises(ValueError):
+            vector_column_matrix([Vector([1, 2]), Vector([1, 2, 3])])


### PR DESCRIPTION
## Release v1.2.0

Adds an eigenvalue solver, enriches the QR decomposition result, and introduces a `tolerance` option across the reduction/solve stack — plus regression fixes for the newly added orthogonality tooling. All 678 tests pass; package builds cleanly (`panchi-1.2.0`).

### Eigenvalues & eigenvectors — new `eigen()`
- `eigen(matrix, max_iterations=1000, tolerance=1e-12)` computes eigenvalues via the **QR algorithm** (iterate `A ← R @ Q`, read the diagonal of the converged upper-triangular iterate).
- Eigenvectors are recovered as the **null space of `A − λI`**, solved numerically (see tolerance below) — true eigenvectors for general real matrices, not just symmetric.
- New `EigenResult` (eigenvalues, eigenvectors, `iterations`, `converged`, `triangular`, `pairs` property) with LU-style `__str__`/`__repr__`.
- Non-convergence (complex / equal-magnitude spectra) is **non-fatal**: returns `converged=False` with no eigenvectors.

### `tolerance` option on `ref` / `rref` / `solve`
- Threaded an optional `tolerance` parameter (default `0.0`) through the reduction stack and `solve()`. With `0.0`, `abs(x) <= tolerance` is equivalent to `x == 0`, so **exact behavior is byte-for-byte preserved**.
- A positive tolerance treats near-zero pivots as zero — this is what lets `solve((A − λI)x = 0)` expose the null space when `λ` is a floating-point estimate. Now a general public capability for approximately-singular systems.

### QR decomposition (fixes + enrichment)
- Restored `orthogonal_complement` (accidental overwrite), fixed Gram-Schmidt normalization and projection math, and `R = Qᵀ @ A`.
- Added docstrings, error messages, and exports for `vector_column_matrix`, `gram_schmidt`, `vector_projection`, `qr_decomposition`.
- Enriched `QRDecomposition` with a column-by-column Gram-Schmidt walkthrough (`__str__`) and compact `__repr__`, mirroring `LUDecomposition`.

### Housekeeping
- Version synced to `1.2.0` (`pyproject.toml` and `panchi/__init__.py` had drifted).

### Test coverage
678 passing (was 623 at branch start). New suites: `test_qr_decomposition`, `test_gram_schmidt`, `test_vector_column_matrix`, `test_eigen`, plus `TestSolveTolerance` and `TestReductionTolerance`.

### Notes / limitations
- Real eigenvalues only; unshifted QR is slow for clustered spectra; repeated eigenvalues yield a shared vector. Wilkinson/Rayleigh shifts noted as a future enhancement.
- Tag `v1.2.0` to be created on `main` after merge (matching the v1.1.0 flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
