### PR TITLE
docs: document QR decomposition, eigen(), and solve tolerance

### DIFF
--- a/docs/api/algorithms.md
+++ b/docs/api/algorithms.md
@@ -1,11 +1,13 @@
 # panchi.algorithms
 
 ```python
-from panchi.algorithms import ref, rref, lu
+from panchi.algorithms import ref, rref, lu, qr_decomposition
 from panchi.algorithms import RowSwap, RowScale, RowAdd
-from panchi.algorithms import Reduction, LUDecomposition, InverseResult, Solution
-from panchi.algorithms import inverse, solve, determinant_lu
+from panchi.algorithms import Reduction, LUDecomposition, QRDecomposition
+from panchi.algorithms import InverseResult, Solution, EigenResult
+from panchi.algorithms import inverse, solve, determinant_lu, eigen
 from panchi.algorithms import dot, cross, orthogonal_complement
+from panchi.algorithms import gram_schmidt, vector_projection
 ```
 
 ## Row operations
@@ -26,6 +28,12 @@ from panchi.algorithms import dot, cross, orthogonal_complement
 
 ::: panchi.algorithms.lu
 
+::: panchi.algorithms.qr_decomposition
+
+## Eigenvalues
+
+::: panchi.algorithms.eigen
+
 ## Solvers
 
 ::: panchi.algorithms.inverse
@@ -38,12 +46,20 @@ from panchi.algorithms import dot, cross, orthogonal_complement
 
 ::: panchi.algorithms.orthogonal_complement
 
+::: panchi.algorithms.gram_schmidt
+
+::: panchi.algorithms.vector_projection
+
 ## Result types
 
 ::: panchi.algorithms.Reduction
 
 ::: panchi.algorithms.LUDecomposition
 
+::: panchi.algorithms.QRDecomposition
+
 ::: panchi.algorithms.InverseResult
 
 ::: panchi.algorithms.Solution
+
+::: panchi.algorithms.EigenResult

--- a/docs/index.md
+++ b/docs/index.md
@@ -30,8 +30,9 @@ If you want to understand the concepts behind the code, the [User Guide](user-gu
 - Factory functions: identity, zero and ones matrices, diagonal, rotation matrices, and more
 - Elementary row operations as first-class objects
 - Row reduction to REF and RREF
-- LU decomposition with partial pivoting
-- Matrix inverse and linear system solving
+- LU and QR decomposition (QR via Gram-Schmidt)
+- Eigenvalues and eigenvectors via the QR algorithm
+- Matrix inverse and linear system solving (with an optional numerical tolerance)
 - Rich result formats for algorithms, allowing for step-by-step inspection
 - [2D visualization](user-guide/visualizations.md) of vectors, linear transformations, and spans via Matplotlib, with optional Manim backend
 

--- a/docs/user-guide/decompositions.md
+++ b/docs/user-guide/decompositions.md
@@ -1,6 +1,6 @@
 # Decompositions
 
-A matrix decomposition factors a matrix into simpler pieces that reveal its structure. panchi currently implements LU decomposition with partial pivoting.
+A matrix decomposition factors a matrix into simpler pieces that reveal its structure. panchi implements **LU** decomposition with partial pivoting, **QR** decomposition via Gram-Schmidt, and eigenvalue/eigenvector computation via the **QR algorithm**.
 
 ## LU Decomposition
 
@@ -68,3 +68,106 @@ The row swaps are recorded in P, so the factorisation relationship remains exact
 U is the result of Gaussian elimination applied to P @ A — it is the REF of the permuted matrix. L encodes the elimination steps: each entry below the diagonal in column j of L is the scalar that was used to zero out that row's entry in column j.
 
 This means the steps recorded in `decomp.steps` and the entries of L are two ways of reading the same information.
+
+## QR Decomposition
+
+QR decomposition factors a matrix A into a matrix Q with orthonormal columns and an upper triangular matrix R:
+
+$$A = Q R$$
+
+panchi builds Q by applying the **Gram-Schmidt process** to the columns of A, then recovers R as $R = Q^\top A$.
+
+```python
+import panchi as pan
+from panchi.algorithms import qr_decomposition
+
+A = pan.Matrix([[1, 1, 0],
+                [1, 0, 1],
+                [0, 1, 1]])
+
+decomp = qr_decomposition(A)
+
+print(decomp.q)  # Q — orthonormal columns
+print(decomp.r)  # R — upper triangular
+```
+
+The decomposition satisfies the invariant `A == Q @ R` (up to floating-point rounding, since normalization introduces square roots).
+
+### The QRDecomposition object
+
+`qr_decomposition()` returns a `QRDecomposition` result object:
+
+```python
+decomp.original  # the original matrix A
+decomp.q         # Q
+decomp.r         # R
+decomp.steps     # the per-column Gram-Schmidt steps used to build Q
+```
+
+Printing it walks through the orthonormalization column by column, then shows the `A = Q @ R` relationship:
+
+```python
+print(decomp)
+# QR decomposition of 3×3 matrix — 3 steps
+#
+# Step 1: v0 = [1, 1, 0]
+#   orthogonal: [1, 1, 0]
+#   normalize -> q0: [0.707..., 0.707..., 0.0]
+# ...
+#
+# A = Q @ R
+# ...
+```
+
+!!! note
+    QR decomposition here is the reduced ("thin") form and assumes the columns of A are linearly independent. Dependent columns produce a zero vector during Gram-Schmidt, which cannot be normalized and raises `ZeroDivisionError`.
+
+## Eigenvalues and eigenvectors
+
+`eigen()` computes the eigenvalues and eigenvectors of a square matrix using the **QR algorithm**: it repeatedly decomposes the matrix and reassembles it as `R @ Q`. For matrices with real eigenvalues this sequence converges to an upper triangular matrix whose diagonal entries are the eigenvalues.
+
+```python
+import panchi as pan
+from panchi.algorithms import eigen
+
+A = pan.Matrix([[2, 1],
+                [1, 2]])
+
+result = eigen(A)
+
+print(result.eigenvalues)   # ≈ [3.0, 1.0]
+print(result.eigenvectors)  # unit eigenvectors, paired by index
+```
+
+Each eigenvector satisfies `A @ v ≈ λ * v`:
+
+```python
+for value, vector in result.pairs:
+    assert all(
+        abs((A @ vector)[i] - (value * vector)[i]) < 1e-6
+        for i in range(vector.dims)
+    )
+```
+
+Eigenvectors are recovered as the null space of $A - \lambda I$: since a computed eigenvalue is an approximation, panchi solves `(A - λI) x = 0` with a small numerical [tolerance](solving-systems.md#numerical-tolerance) so the near-singular matrix is treated as singular.
+
+### The EigenResult object
+
+```python
+result.original      # the original matrix A
+result.eigenvalues   # list of eigenvalues (diagonal of the converged iterate)
+result.eigenvectors  # list of eigenvectors, paired with eigenvalues
+result.pairs         # list of (eigenvalue, eigenvector) tuples
+result.iterations    # number of QR iterations performed
+result.converged     # whether the iteration settled within the limit
+result.triangular    # the final (near) upper-triangular matrix
+```
+
+!!! warning "Real eigenvalues only"
+    The unshifted QR algorithm converges for matrices with **real** eigenvalues. Matrices with complex eigenvalues (for example a rotation matrix) or eigenvalues of equal magnitude may not converge. In that case `result.converged` is `False` and `result.eigenvectors` is empty — `eigen()` never raises for this, so you can still inspect the partial result.
+
+    You can adjust `max_iterations` and `tolerance` if needed:
+
+    ```python
+    eigen(A, max_iterations=5000, tolerance=1e-14)
+    ```

--- a/docs/user-guide/solving-systems.md
+++ b/docs/user-guide/solving-systems.md
@@ -101,3 +101,24 @@ For homogeneous systems (b = 0), the particular solution is the zero vector and 
 - If a pivot appears in the last (b) column, the system is inconsistent.
 - If there are fewer pivots than variables, there are free variables and infinite solutions.
 - Otherwise, back-substitution yields the unique solution.
+
+## Numerical tolerance
+
+By default `solve()` uses **exact** comparisons: a pivot counts as zero only if it is exactly `0`. This is the right behaviour for integer and `Fraction` inputs, where the arithmetic is exact.
+
+Floating-point matrices are trickier. A matrix that is *mathematically* singular can end up with a tiny non-zero residual pivot (like `1e-15`) after elimination, so an exact solve would wrongly report it as full rank. The optional `tolerance` parameter treats any pivot at or below that magnitude as zero:
+
+```python
+from panchi.algorithms import solve
+
+# Only approximately singular — the second row is a hair off the first.
+A = pan.Matrix([[1.0, 1.0],
+                [1.0, 1.0 + 1e-12]])
+
+solve(A, pan.Vector([0.0, 0.0]))                 # status 'unique'  (exact)
+solve(A, pan.Vector([0.0, 0.0]), tolerance=1e-6) # status 'infinite' → null space
+```
+
+The default of `tolerance=0.0` reproduces the exact behaviour exactly, so existing code is unaffected. The same `tolerance` parameter is available on `ref()` and `rref()`.
+
+This is the mechanism [`eigen()`](decompositions.md#eigenvalues-and-eigenvectors) uses to recover eigenvectors as the null space of an approximately-singular `A - λI`.


### PR DESCRIPTION
- index: list QR, eigenvalues, and the tolerant solve under "What panchi covers".
- api/algorithms: register qr_decomposition, eigen, gram_schmidt, vector_projection, QRDecomposition, and EigenResult (imports + mkdocstrings).
- user-guide/decompositions: add QR Decomposition and Eigenvalues/eigenvectors sections (A = QR, A @ v ≈ λv, EigenResult, real-eigenvalue limitation).
- user-guide/solving-systems: add a "Numerical tolerance" section covering the new tolerance option on solve/ref/rref and its link to eigenvector recovery.
